### PR TITLE
Feature: Game switcher

### DIFF
--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -22,6 +22,7 @@
 #define SIMPLE_MODE_PATH SHARED_USERDATA_PATH "/enable-simple-mode"
 #define AUTO_RESUME_PATH SHARED_USERDATA_PATH "/.minui/auto_resume.txt"
 #define AUTO_RESUME_SLOT 9
+#define GAME_SWITCHER_PERSIST_PATH SHARED_USERDATA_PATH "/.minui/game_switcher.txt"
 
 #define FAUX_RECENT_PATH SDCARD_PATH "/Recently Played"
 #define COLLECTIONS_PATH SDCARD_PATH "/Collections"

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -1664,6 +1664,13 @@ static void input_poll_callback(void) {
 	if (PAD_isPressed(BTN_MENU) && (PAD_isPressed(BTN_PLUS) || PAD_isPressed(BTN_MINUS))) {
 		ignore_menu = 1;
 	}
+	if (PAD_isPressed(BTN_MENU) && PAD_isPressed(BTN_SELECT)) {
+		ignore_menu = 1;
+		Menu_saveState();
+		putFile(GAME_SWITCHER_PERSIST_PATH, game.path + strlen(SDCARD_PATH));
+		GFX_clear(screen);
+		quit = 1;
+	}
 	
 	if (PAD_justPressed(BTN_POWER)) {
 		if (thread_video) {

--- a/workspace/macos/platform/platform.h
+++ b/workspace/macos/platform/platform.h
@@ -37,12 +37,14 @@
 
 ///////////////////////////////
 
+// see https://wiki.libsdl.org/SDL2/SDL_Scancode
+
 #define CODE_UP			82
 #define CODE_DOWN		81
 #define CODE_LEFT		80
 #define CODE_RIGHT		79
 
-#define CODE_SELECT		52
+#define CODE_SELECT		53
 #define CODE_START		40
 
 #define CODE_A			22


### PR DESCRIPTION
I'm currently implementing this in my fork, but it looks like you have it planned as well - might as well contribute :)

Quick demo here: https://youtu.be/AJ7bhrWCEMA

- In MinUI main menu: press SELECT to bring it up. Uses Recents + their thumbnails, if available. Open Game with A, or resume from last save with X.
- Ingame: press MENU+SELECT to quicksave and quit back into game switcher.
