### PR TITLE
Theme fixes

### DIFF
--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -70,6 +70,9 @@ extern uint32_t RGB_BLACK;
 extern uint32_t RGB_LIGHT_GRAY;
 extern uint32_t RGB_GRAY;
 extern uint32_t RGB_DARK_GRAY;
+extern uint32_t THEME_COLOR1;
+extern uint32_t THEME_COLOR2;
+extern uint32_t THEME_COLOR3;
 extern float currentratio;
 extern int currentbufferfree;
 extern int currentframecount;
@@ -209,8 +212,9 @@ scaler_t GFX_getAAScaler(GFX_Renderer* renderer);
 void GFX_freeAAScaler(void);
 
 // NOTE: all dimensions should be pre-scaled
-void GFX_blitAssetColor(int asset, SDL_Rect* src_rect, SDL_Surface* dst, SDL_Rect* dst_rect,char color[3]);
+void GFX_blitAssetColor(int asset, SDL_Rect* src_rect, SDL_Surface* dst, SDL_Rect* dst_rect, uint32_t asset_color);
 void GFX_blitAsset(int asset, SDL_Rect* src_rect, SDL_Surface* dst, SDL_Rect* dst_rect);
+void GFX_blitPillColor(int asset, SDL_Surface* dst, SDL_Rect* dst_rect, uint32_t asset_color, uint32_t fill_color);
 void GFX_blitPill(int asset, SDL_Surface* dst, SDL_Rect* dst_rect);
 void GFX_blitPillLight(int asset, SDL_Surface* dst, SDL_Rect* dst_rect);
 void GFX_blitPillDark(int asset, SDL_Surface* dst, SDL_Rect* dst_rect);
@@ -226,7 +230,7 @@ int GFX_blitButtonGroup(char** hints, int primary, SDL_Surface* dst, int align_r
 
 void GFX_sizeText(TTF_Font* font, char* str, int leading, int* w, int* h);
 void GFX_blitText(TTF_Font* font, char* str, int leading, SDL_Color color, SDL_Surface* dst, SDL_Rect* dst_rect);
-void GFX_setAmbientColor();
+void GFX_setAmbientColor(const void *data, unsigned width, unsigned height, size_t pitch,int mode);
 ///////////////////////////////
 
 typedef struct SND_Frame {

--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -34,12 +34,8 @@
 #define RESUME_SLOT_PATH "/tmp/resume_slot.txt"
 #define NOUI_PATH "/tmp/noui"
 
-
-#define EXPAND_COLOR(color) color[0], color[1], color[2]
-
 #define TRIAD_WHITE 		0xff,0xff,0xff
 #define TRIAD_BLACK 		0x00,0x00,0x00
-
 #define TRIAD_LIGHT_GRAY 	0x7f,0x7f,0x7f
 #define TRIAD_GRAY 			0x99,0x99,0x99
 #define TRIAD_DARK_GRAY 	0x26,0x26,0x26

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -3947,7 +3947,7 @@ static int Menu_options(MenuList* list) {
 
 				if (j==selected_row) {
 					// gray pill
-					GFX_blitPill(ASSET_BUTTON, screen, &(SDL_Rect){
+					GFX_blitPillLight(ASSET_BUTTON, screen, &(SDL_Rect){
 						ox,
 						oy+SCALE1(j*BUTTON_SIZE),
 						mw,
@@ -4029,7 +4029,7 @@ static int Menu_options(MenuList* list) {
 
 				if (j==selected_row) {
 					// gray pill
-					GFX_blitPill(ASSET_BUTTON, screen, &(SDL_Rect){
+					GFX_blitPillLight(ASSET_BUTTON, screen, &(SDL_Rect){
 						ox,
 						oy+SCALE1(j*BUTTON_SIZE),
 						mw,


### PR DESCRIPTION
- Stay backwards compatible and dont break regular blitPill/blitAsset with theme colors
- Consistent storage of rgb triplets in uint32_t
- Expose theme colors globally
- Renamed global `color<n>` theme colors to `THEME_COLOR<n>`

Not sure if I missed any edge cases, looks good on my side though.