### PR TITLE
fix: proper rumble scaling for tg5040

### DIFF
--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -659,8 +659,22 @@ void PLAT_setCPUSpeed(int speed) {
 }
 
 #define RUMBLE_PATH "/sys/class/gpio/gpio227/value"
+#define RUMBLE_VOLTAGE_PATH "/sys/class/motor/voltage"
+#define MAX_STRENGTH 0xFFFF
+#define MIN_VOLTAGE 500000
+#define MAX_VOLTAGE 3500000
+
 void PLAT_setRumble(int strength) {
-	putInt(RUMBLE_PATH, (strength && !GetMute())?1:0);
+	if(strength != 0) {
+		int voltage = MIN_VOLTAGE + (int)((strength * (long long)(MAX_VOLTAGE - MIN_VOLTAGE)) / MAX_STRENGTH);
+		putInt(RUMBLE_VOLTAGE_PATH, voltage);
+	}
+	else {
+		putInt(RUMBLE_VOLTAGE_PATH, MAX_VOLTAGE);
+	}
+
+	// enable
+	putInt(RUMBLE_PATH, (strength && !GetMute()) ? 1 : 0);
 }
 
 int PLAT_pickSampleRate(int requested, int max) {

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -662,7 +662,7 @@ void PLAT_setCPUSpeed(int speed) {
 #define RUMBLE_VOLTAGE_PATH "/sys/class/motor/voltage"
 #define MAX_STRENGTH 0xFFFF
 #define MIN_VOLTAGE 500000
-#define MAX_VOLTAGE 3500000
+#define MAX_VOLTAGE 3300000
 
 void PLAT_setRumble(int strength) {
 	if(strength != 0) {


### PR DESCRIPTION
Any rumble enjoyers out there? 

Most MinUI platforms currently only have a binary on/off rumble, even though libretro supplies `strength`. This PR adds handling for that and properly scales the libretro rumble strength to the rumble motor voltage. Voltage bounds are taken from TSP, I assume Brick will have the same. Tested with Drill Dozer on GBA and its a night and day difference. 

Feedback welcome!