### PR TITLE
Unified start/resume to be on BTN_X

### DIFF
--- a/workspace/all/minui/minui.c
+++ b/workspace/all/minui/minui.c
@@ -1415,21 +1415,16 @@ int main (int argc, char *argv[]) {
 				switcher_selected = 0;
 				dirty = 1;
 			}
-			else if (recents->count > 0 && can_resume && PAD_justReleased(BTN_RESUME)) {
+			else if (recents->count > 0 && PAD_justReleased(BTN_A)) {
 				// TODO: This is crappy af - putting this here since it works, but
 				// super inefficient. Why are Recents not decorated with type, and need
 				// to be remade into Entries via getRecents()? - need to understand the 
 				// architecture more...
 				Entry *selectedEntry = entryFromRecent(recents->items[switcher_selected]);
-				should_resume = 1;
+				should_resume = can_resume;
 				Entry_open(selectedEntry);
 				dirty = 1;
 				Entry_free(selectedEntry);
-			}
-			else if (recents->count > 0 && PAD_justReleased(BTN_A)) {
-				Entry *selectedEntry = entryFromRecent(recents->items[switcher_selected]);
-				Entry_open(selectedEntry);
-				dirty = 1;
 			}
 			else if (PAD_justPressed(BTN_RIGHT)) {
 				switcher_selected++;


### PR DESCRIPTION
Removed regular start option in favour of only having resume. Fixes #31.