### PR TITLE
fix: Force double buffer to make sure to have lowest input lag possible

### DIFF
--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -474,6 +474,8 @@ SDL_Surface* PLAT_initVideo(void) {
 
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1); // ensure double buffering only
+	SDL_GL_SetSwapInterval(1); // ensure double buffering only
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY,"1");
 	SDL_SetHint(SDL_HINT_RENDER_DRIVER,"opengl");
 	SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION,"1");


### PR DESCRIPTION
Ensure there's only 2 buffers, 1 to draw to the screen and 1 to render current game frame on. 

Probably its already using this by default (On most systems triple (or more) buffer is optional), but just to be sure it doesn't hurt to set it explicitly.  

In case you are wondering why no single buffer? It doesn't exists while using vsync. The GPU needs atleast 2 buffers, one which the GPU is reading and drawing to your screen and another one that can be used to render your stuff to. Each frame you just swap the frames around, thus why the drawing call is called GL_Swap();  