### PR TITLE
fix: ensure keymon and batmon build their necessary libraries

### DIFF
--- a/workspace/all/batmon/makefile
+++ b/workspace/all/batmon/makefile
@@ -30,7 +30,7 @@ LDFLAGS	 += -lmsettings -lbatmondb -lsqlite3
 
 PRODUCT= build/$(PLATFORM)/$(TARGET).elf
 
-all: $(PREFIX_LOCAL)/include/msettings.h
+all: $(PREFIX_LOCAL)/include/msettings.h $(PREFIX_LOCAL)/include/batmondb.h
 	mkdir -p build/$(PLATFORM)
 	$(CC) $(SOURCE) -o $(PRODUCT) $(CFLAGS) $(LDFLAGS)
 clean:
@@ -38,3 +38,6 @@ clean:
 
 $(PREFIX_LOCAL)/include/msettings.h:
 	cd ../../$(PLATFORM)/libmsettings && make
+
+$(PREFIX_LOCAL)/include/batmondb.h:
+	cd ../libbatmondb && make

--- a/workspace/tg5040/keymon/makefile
+++ b/workspace/tg5040/keymon/makefile
@@ -1,16 +1,22 @@
-#keymon
-
 ifeq (,$(CROSS_COMPILE))
 $(error missing CROSS_COMPILE for this toolchain)
 endif
 
+ifeq (,$(PLATFORM))
+PLATFORM=$(UNION_PLATFORM)
+endif
+
 TARGET = keymon
+PRODUCT = $(TARGET).elf
 
 CC = $(CROSS_COMPILE)gcc
 CFLAGS	= -Os -lmsettings -lpthread -lrt -ldl -Wl,--gc-sections -s
 CFLAGS  += -I. -I../../all/common -I../platform/ -I$(PREFIX_LOCAL)/include -L$(PREFIX_LOCAL)/lib -DPLATFORM=\"$(UNION_PLATFORM)\"
 
-all:
-	$(CC) $(TARGET).c -o $(TARGET).elf $(CFLAGS)
+all: $(PREFIX)/include/msettings.h
+	$(CC) $(TARGET).c -o $(PRODUCT) $(CFLAGS)
 clean:
-	rm -rf $(TARGET).elf
+	rm -rf $(PRODUCT)
+
+$(PREFIX)/include/msettings.h:
+	cd /root/workspace/$(PLATFORM)/libmsettings && make


### PR DESCRIPTION
Without this change, the necessary includes aren't generated if we somehow target only particular parts of a release. Specifically, this will break any sort of parallelism of make.