### PR TITLE
feat: New option to honor inner file name of archived roms, if it differs

### DIFF
--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -57,6 +57,7 @@ void CFG_defaults(NextUISettings *cfg)
         .romsUseFolderBackground = CFG_DEFAULT_ROMSUSEFOLDERBACKGROUND,
         .saveFormat = CFG_DEFAULT_SAVEFORMAT,
         .stateFormat = CFG_DEFAULT_STATEFORMAT,
+        .useExtractedFileName = CFG_DEFAULT_EXTRACTEDFILENAME,
 
         .wifi = CFG_DEFAULT_WIFI,
         .wifiDiagnostics = CFG_DEFAULT_WIFI_DIAG,
@@ -210,6 +211,11 @@ void CFG_init(FontLoad_callback_t cb, ColorSet_callback_t ccb)
             if (sscanf(line, "stateFormat=%i", &temp_value) == 1)
             {
                 CFG_setStateFormat(temp_value);
+                continue;
+            }
+            if (sscanf(line, "useExtractedFileName=%i", &temp_value) == 1)
+            {
+                CFG_setUseExtractedFileName((bool)temp_value);
                 continue;
             }
             if (sscanf(line, "muteLeds=%i", &temp_value) == 1)
@@ -532,6 +538,17 @@ void CFG_setStateFormat(int f)
     CFG_sync();
 }
 
+bool CFG_getUseExtractedFileName(void)
+{
+    return settings.useExtractedFileName;
+}
+
+void CFG_setUseExtractedFileName(bool use)
+{
+    settings.useExtractedFileName = use;
+    CFG_sync();
+}
+
 bool CFG_getMuteLEDs(void)
 {
     return settings.muteLeds;
@@ -725,6 +742,10 @@ void CFG_get(const char *key, char *value)
     {
         sprintf(value, "%i", CFG_getStateFormat());
     }
+    else if (strcmp(key, "useExtractedFileName") == 0)
+    {
+        sprintf(value, "%i", CFG_getUseExtractedFileName());
+    }
     else if (strcmp(key, "muteLeds") == 0)
     {
         sprintf(value, "%i", CFG_getMuteLEDs());
@@ -812,6 +833,7 @@ void CFG_sync(void)
     fprintf(file, "romfolderbg=%i\n", settings.romsUseFolderBackground);
     fprintf(file, "saveFormat=%i\n", settings.saveFormat);
     fprintf(file, "stateFormat=%i\n", settings.stateFormat);
+    fprintf(file, "useExtractedFileName=%i\n", settings.useExtractedFileName);
     fprintf(file, "muteLeds=%i\n", settings.muteLeds);
     fprintf(file, "artWidth=%i\n", (int)(settings.gameArtWidth * 100));
     fprintf(file, "wifi=%i\n", settings.wifi);
@@ -852,6 +874,7 @@ void CFG_print(void)
     printf("\t\"romfolderbg\": %i,\n", settings.romsUseFolderBackground);
     printf("\t\"saveFormat\": %i,\n", settings.saveFormat);
     printf("\t\"stateFormat\": %i,\n", settings.stateFormat);
+    printf("\t\"useExtractedFileName\": %i,\n", settings.useExtractedFileName);
     printf("\t\"muteLeds\": %i,\n", settings.muteLeds);
     printf("\t\"artWidth\": %i,\n", (int)(settings.gameArtWidth * 100));
     printf("\t\"wifi\": %i,\n", settings.wifi);

--- a/workspace/all/common/config.h
+++ b/workspace/all/common/config.h
@@ -99,6 +99,7 @@ typedef struct
 	// Emulator
 	int saveFormat;
 	int stateFormat;
+	bool useExtractedFileName;
 
 	// Haptic
 	bool haptics;
@@ -135,6 +136,7 @@ typedef struct
 #define CFG_DEFAULT_ROMSUSEFOLDERBACKGROUND true
 #define CFG_DEFAULT_SAVEFORMAT SAVE_FORMAT_SAV
 #define CFG_DEFAULT_STATEFORMAT STATE_FORMAT_SAV
+#define CFG_DEFAULT_EXTRACTEDFILENAME false
 #define CFG_DEFAULT_MUTELEDS false
 #define CFG_DEFAULT_GAMEARTWIDTH 0.45
 #define CFG_DEFAULT_WIFI false
@@ -214,6 +216,9 @@ void CFG_setSaveFormat(int);
 // 1 - .state.<n> (compressed rzip)
 int CFG_getStateFormat(void);
 void CFG_setStateFormat(int);
+// use extracted file name instead of archive name (for cores that do not support archives natively)
+bool CFG_getUseExtractedFileName(void);
+void CFG_setUseExtractedFileName(bool);
 // Enable/disable mute also shutting off LEDs.
 bool CFG_getMuteLEDs(void);
 void CFG_setMuteLEDs(bool);

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -156,6 +156,10 @@ static void Game_open(char* path) {
 		strcpy((char*)game.tmp_path, tmppath);
 		skipzip = 1;
 		free(tmppath);
+		// Update the game name to the extracted file name instead of the zip name
+		if (CFG_getUseExtractedFileName()) {
+			strcpy((char*)game.name, strrchr(game.tmp_path, '/')+1);
+		}
 	} else {
 		printf("File does not exist in %s\n",tmpfldr);
 	}
@@ -185,6 +189,10 @@ static void Game_open(char* path) {
 			LOG_info("Extracting zip file manually: %s\n", game.path);
 			if(!extract_zip(extensions))
 				return;
+			// Update the game name to the extracted file name instead of the zip name
+			if (CFG_getUseExtractedFileName()) {
+				strcpy((char*)game.name, strrchr(game.tmp_path, '/')+1);
+			}
 		}
 		else {
 			LOG_info("Core can handle zip file: %s\n", game.path);

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -316,6 +316,10 @@ int main(int argc, char *argv[])
             { return CFG_getStateFormat(); }, [](const std::any &value)
             { CFG_setStateFormat(std::any_cast<int>(value)); },
             []() { CFG_setStateFormat(CFG_DEFAULT_STATEFORMAT);}},
+            new MenuItem{ListItemType::Generic, "Use extracted file name", "Use the extracted file name instead of the archive name.\nOnly applies to cores that do not handle archives natively", {false, true}, on_off, 
+            []() -> std::any{ return CFG_getUseExtractedFileName(); },
+            [](const std::any &value){ CFG_setUseExtractedFileName(std::any_cast<bool>(value)); },
+            []() { CFG_setUseExtractedFileName(CFG_DEFAULT_EXTRACTEDFILENAME);}},
 
             new MenuItem{ListItemType::Button, "Reset to defaults", "Resets all options in this menu to their default values.", ResetCurrentMenu},
         });


### PR DESCRIPTION
This patch aligns the "retroarch" save/state naming behavior with actual retroarch behavior. 

- For a zipped ROM named `Super Example World.zip` that contains a less sanitized ROM, e.g. `Super Example World (USA, Europe).gba`, the save/state file will inherit the actual, extracted ROM base name: `Super Example World (USA, Europe).srm`
- This will be a breaking change when enabled, just as changing the save/state format itself.
- Besides obviously affecting the savegames, this also influences other instances of `game.name` being used - for example cheat files, RTC storage, as well as screenshots and config names.