### PR TITLE
fix: make sure we iterate extra input devices from BT/USB-C sources

### DIFF
--- a/workspace/tg5040/keymon/keymon.c
+++ b/workspace/tg5040/keymon/keymon.c
@@ -40,7 +40,7 @@
 
 #define MUTE_STATE_PATH "/sys/class/gpio/gpio243/value"
 
-#define INPUT_COUNT 4
+#define INPUT_COUNT 5
 static int inputs[INPUT_COUNT] = {};
 static struct input_event ev;
 

--- a/workspace/tg5040/libmsettings/msettings.c
+++ b/workspace/tg5040/libmsettings/msettings.c
@@ -1116,32 +1116,6 @@ static int get_a2dp_simple_control_name(char *buf, size_t buflen) {
     return 0;
 }
 
-// Find the first PCM playback volume control via amixer
-static int get_usbdac_simple_control_name(char *buf, size_t buflen) {
-    FILE *fp = popen("amixer scontrols", "r");
-    if (!fp) return 0;
-
-    char line[256];
-    while (fgets(line, sizeof(line), fp)) {
-        char *start = strchr(line, '\'');
-        char *end = strrchr(line, '\'');
-        if (start && end && end > start) {
-            size_t len = end - start - 1;
-            if (len < buflen) {
-                strncpy(buf, start + 1, len);
-                buf[len] = '\0';
-                if (strstr(buf, "PCM")) { // first PCM simple control
-                    pclose(fp);
-                    return 1;
-                }
-            }
-        }
-    }
-
-    pclose(fp);
-    return 0;
-}
-
 void SetRawVolume(int val) { // in: 0-100
 	if (settings->mute) 
 		val = scaleVolume(GetMutedVolume());


### PR DESCRIPTION
This should probably just be dynamic, but refactoring keymon is not on my shortlist right now.

This was found as a result of a bug reported for #485, but isnt limited to it. This should also fix any curious cases of inputs not being registered for additional BT/USB-C controllers and similar cases. 