### PR TITLE
fix: make sure single quotes are escaped properly

### DIFF
--- a/workspace/tg5040/libmsettings/msettings.c
+++ b/workspace/tg5040/libmsettings/msettings.c
@@ -1106,6 +1106,19 @@ static int get_a2dp_simple_control_name(char *buf, size_t buflen) {
                 buf[len] = '\0';
                 if (strstr(buf, "A2DP")) { // first A2DP simple control
                     pclose(fp);
+					// escape any single quotes in the name
+					char esc_buf[128];
+					char *src = buf;
+					char *dst = esc_buf;
+					while(*src && (dst - esc_buf) < (sizeof(esc_buf) - 2)) {
+						if(*src == '\'') {
+							*dst++ = '\\';
+						}
+						*dst++ = *src++;
+					}
+					*dst = '\0';
+					strncpy(buf, esc_buf, buflen);
+					buf[buflen - 1] = '\0';
                     return 1;
                 }
             }


### PR DESCRIPTION
Fix device names like `Aaron's Pixel Buds Pro A2DP` still failing to update volume due to the single quote not being escaped properly