### PR TITLE
shaders: add scanline.cfg config

### DIFF
--- a/skeleton/BASE/Shaders/scanlines.cfg
+++ b/skeleton/BASE/Shaders/scanlines.cfg
@@ -1,0 +1,6 @@
+minarch_nrofshaders = 1
+minarch_shader1 = res-independent-scanlines.glsl
+minarch_shader1_filter = NEAREST
+minarch_shader1_srctype = source
+minarch_shader1_scaletype = source
+minarch_shader1_upscale = screen


### PR DESCRIPTION
Add a scanline.cfg config for users who don't want barrel-distortion active (old-tv.cfg).

This is easy enough for users to do on their own, but I don't see the harm in just having it available as a default config.