### PR TITLE
shader compat: add GL_OES_standard_derivatives when loading .glsl files

### DIFF
--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -348,6 +348,10 @@ GLuint load_shader_from_file(GLenum type, const char* filename, const char* path
         define = "#define FRAGMENT\n";
         default_precision =
             "#ifdef GL_ES\n"
+            // compat fix for fwidth, dFdx, dFdy
+            "#ifdef GL_OES_standard_derivatives\n"
+            "#extension GL_OES_standard_derivatives : enable\n"
+            "#endif\n"
             "#ifdef GL_FRAGMENT_PRECISION_HIGH\n"
             "precision highp float;\n"
             "#else\n"


### PR DESCRIPTION


Fixes compat with shaders that use fwidth(), dFdx() and dFdy() 

These include a few useful RetroArch interpolation, blur and CRT shaders that are well suited for handhelds.