### PR TITLE
Add Save-State Deletion Shortcut With Confirmation

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -5104,6 +5104,42 @@ static int Menu_message(char* message, char** pairs) {
 	return Menu_messageWithFont(message, pairs, font.medium);
 }
 
+static bool Menu_confirm(char* message) {
+	GFX_setMode(MODE_MAIN);
+	int dirty = 1;
+	bool confirmed = false;
+	while (1) {
+		GFX_startFrame();
+		PAD_poll();
+
+		if (PAD_justPressed(BTN_A)) {
+			confirmed = true;
+			break;
+		}
+		else if (PAD_justPressed(BTN_B)) {
+			confirmed = false;
+			break;
+		}
+
+		PWR_update(&dirty, NULL, Menu_beforeSleep, Menu_afterSleep);
+
+		GFX_clear(screen);
+		GFX_blitMessage(font.medium, message, screen, &(SDL_Rect){
+			SCALE1(PADDING),
+			SCALE1(PADDING),
+			screen->w - SCALE1(2 * PADDING),
+			screen->h - SCALE1(PILL_SIZE + PADDING)
+		});
+		GFX_blitButtonGroup((char*[]){ "B","CANCEL", "A","OKAY", NULL }, 0, screen, 1);
+		GFX_flip(screen);
+		dirty = 0;
+
+		hdmimon();
+	}
+	GFX_setMode(MODE_MENU);
+	return confirmed;
+}
+
 static int Menu_options(MenuList* list);
 
 static int MenuList_freeItems(MenuList* list, int i) {
@@ -6506,6 +6542,25 @@ static void Menu_loadState(void) {
 	}
 }
 
+static void Menu_deleteState(void) {
+	Menu_updateState();
+	if (!menu.save_exists) return;
+
+	int last_slot = state_slot;
+	state_slot = menu.slot;
+
+	char save_path[256];
+	State_getPath(save_path);
+
+	state_slot = last_slot;
+
+	unlink(save_path);
+	unlink(menu.bmp_path);
+	unlink(menu.txt_path);
+	menu.save_exists = 0;
+	menu.preview_exists = 0;
+}
+
 static void Menu_loop(void) {
 
 	int cw, ch;
@@ -6628,6 +6683,16 @@ static void Menu_loop(void) {
 		if (PAD_justPressed(BTN_B) || (BTN_WAKE!=BTN_MENU && PAD_tappedMenu(now))) {
 			status = STATUS_CONT;
 			show_menu = 0;
+		}
+		else if ((selected==ITEM_SAVE || selected==ITEM_LOAD) && PAD_justPressed(BTN_X)) {
+			Menu_updateState();
+			if (!menu.save_exists) {
+				Menu_message("Slot is already empty.", (char*[]){ "A","OKAY", NULL });
+			}
+			else if (Menu_confirm("Delete this save state?")) {
+				Menu_deleteState();
+				dirty = 1;
+			}
 		}
 		else if (PAD_justPressed(BTN_A)) {
 			switch(selected) {


### PR DESCRIPTION
I'm completely new to this project code-wise, but I love NextUI on my Trimui Brick(s): thanks so much for this fantastic OS!
  
This PR naively tries to tackle #226: it would indeed be great if we could remove _Save States_! :slightly_smiling_face:

## Summary

- **hook BTN_X into the Save/Load rows so pressing it prompts the user and, if confirmed, deletes the current slot (or reports that it’s already empty)**
- introduce `Menu_deleteState()` to centralize how save-slot files (state, screenshot, disc info) are removed
- add a reusable `Menu_confirm()` helper so the pause menu can ask for explicit confirmation

## Testing

- launch any core, open the in-game menu, populate a save slot
- highlight Save or Load, press X → confirm deletion → slot contents disappear, preview switches to “Empty Slot”
- press X again on the now-empty slot → receive “Slot is already empty.” notice

WDYT?