### PR TITLE
WIP: build bash as part of base NextUI

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,6 +91,9 @@ endif
 	cp ./workspace/all/clock/build/$(PLATFORM)/clock.elf ./build/EXTRAS/Tools/$(PLATFORM)/Clock.pak/
 	cp ./workspace/all/minput/build/$(PLATFORM)/minput.elf ./build/EXTRAS/Tools/$(PLATFORM)/Input.pak/
 
+	# bourne again shell
+	cp ./workspace/all/bash/build/$(PLATFORM)/bash ./build/SYSTEM/$(PLATFORM)/bin/
+
 	# battery tracking
 	cp ./workspace/all/libbatmondb/build/$(PLATFORM)/libbatmondb.so ./build/SYSTEM/$(PLATFORM)/lib
 	cp ./workspace/all/batmon/build/$(PLATFORM)/batmon.elf ./build/SYSTEM/$(PLATFORM)/bin/

--- a/workspace/all/bash/makefile
+++ b/workspace/all/bash/makefile
@@ -1,0 +1,56 @@
+########################################################### 
+
+ifeq (,$(PLATFORM))
+PLATFORM=$(UNION_PLATFORM)
+endif
+ 
+ifeq (,$(PLATFORM))
+        $(error please specify PLATFORM, eg. PLATFORM=trimui make)
+endif
+ 
+ifeq (,$(CROSS_COMPILE))
+        $(error missing CROSS_COMPILE for this toolchain)
+endif
+
+########################################################### 
+
+BASH_VERSION = 5.2
+BASH_SOURCE = bash-$(BASH_VERSION).tar.gz
+BUILD_DIR = build/bash-$(BASH_VERSION)
+CONFIGURE_ARGS = --without-bash-malloc --host=aarch64-pc-linux-gnu
+
+TARGET = bash
+PRODUCT = build/$(PLATFORM)/bash
+
+.PHONY: all
+all: $(PRODUCT)
+
+$(BASH_SOURCE):
+	@echo "Fetching bash source version $(BASH_VERSION)..."
+	mkdir -p build/
+	wget https://ftp.gnu.org/gnu/bash/$(BASH_SOURCE) -O $(BASH_SOURCE)
+
+$(BUILD_DIR)/configure: $(BASH_SOURCE)
+	@echo "Extracting $(BASH_SOURCE)..."
+	tar -xf $(BASH_SOURCE) -C build
+	rm $(BASH_SOURCE)
+
+$(PRODUCT): $(BUILD_DIR)/configure
+	@echo "Configuring bash..."
+	(cd $(BUILD_DIR) && \
+	./configure $(CONFIGURE_ARGS))
+	
+	@echo "Compiling bash..."
+	(cd $(BUILD_DIR) && \
+	make)
+	
+	@echo "Copying final executable and cleaning up..."
+	mkdir -p build/$(PLATFORM)
+	cp $(BUILD_DIR)/$(TARGET) $(PRODUCT)
+	chown 1000:1000 $(PRODUCT)
+	rm -rf $(BUILD_DIR)
+
+.PHONY: clean
+clean:
+	rm -f $(PRODUCT)
+	rm -rf build/bash-*

--- a/workspace/makefile
+++ b/workspace/makefile
@@ -21,6 +21,7 @@ ifeq ($(PLATFORM), desktop)
 	cd ./all/nextui/ && make
 	cd ./all/minarch/ && make
 	cd ./all/libbatmondb/ && make
+	cd ./all/bash/ && make
 	cd ./all/battery/ && make
 	cd ./all/clock/ && make
 	cd ./all/batmon/ && make
@@ -40,6 +41,7 @@ else
 	cd ./$(PLATFORM)/keymon && make
 	cd ./all/nextui/ && make
 	cd ./all/minarch/ && make
+	cd ./all/bash/ && make
 	cd ./all/battery/ && make
 	cd ./all/clock/ && make
 	cd ./all/libbatmondb/ && make
@@ -84,6 +86,7 @@ endif
 	cd ./$(PLATFORM)/libmsettings && make clean
 	cd ./all/nextui/ && make clean
 	cd ./all/minarch/ && make clean
+	cd ./all/bash/ && make clean
 	cd ./all/battery/ && make clean
 	cd ./all/clock/ && make clean
 	cd ./all/libbatmondb/ && make clean


### PR DESCRIPTION
Note that this was build on top of the 'new-toolchains' branch, so may need a bit of work to get into main (I do not own any commercial Arm64 devices to build with.)

Currently just builds bash by fetching a tar from gnu.org (much faster than a git checkout, bash's repository is gigantic).

I'm mostly opening this PR to get feedback on integrating this into the NextUI build process properly. What's here should work, but the makefile is basically just an adapted bash script that doesn't properly use any of the make variables (which may be an issue for future platforms)