### PR TITLE
Fix cores not starting in x86 cross compile

### DIFF
--- a/workspace/all/minarch/makefile
+++ b/workspace/all/minarch/makefile
@@ -62,12 +62,12 @@ all: clean libretro-common $(PREFIX_LOCAL)/include/msettings.h
 else
 all: clean libretro-common libsrm.a $(PREFIX_LOCAL)/include/msettings.h
 	mkdir -p build/$(PLATFORM)
-	cp $(PREFIX)/lib/libsamplerate.* build/$(PLATFORM)
+	cp $(PREFIX)/lib/libsamplerate.so.0 build/$(PLATFORM)
 	# This is a bandaid fix, needs to be cleaned up if/when we expand to other platforms.
-	cp $(PREFIX)/lib/libzip.* build/$(PLATFORM)
-	cp $(PREFIX)/lib/libbz2.* build/$(PLATFORM)
-	cp $(PREFIX)/lib/liblzma.* build/$(PLATFORM)
-	cp $(PREFIX)/lib/libzstd.* build/$(PLATFORM)
+	cp $(PREFIX)/lib/libzip.so.5 build/$(PLATFORM)
+	cp $(PREFIX)/lib/libbz2.so.1.0 build/$(PLATFORM)
+	cp $(PREFIX)/lib/liblzma.so.5 build/$(PLATFORM)
+	cp $(PREFIX)/lib/libzstd.so.1 build/$(PLATFORM)
 	$(CC) $(SOURCE) -o $(PRODUCT) $(CFLAGS) $(LDFLAGS)
 endif
 


### PR DESCRIPTION
Corrects a discrepancy in the two copy stages done in makefiles: now both stages copy all available versions of a .so file

workspace/all/minarch/makefile now matches root makefile