### PR TITLE
minarch: show save timestamp in preview

### DIFF
--- a/workspace/all/common/utils.c
+++ b/workspace/all/common/utils.c
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <ctype.h>
 #include <sys/time.h>
+#include <sys/stat.h>
 #include "defines.h"
 #include "utils.h"
 
@@ -414,6 +415,13 @@ void trimSortingMeta(char** str) { // eg. `001) `
 
 int exists(char* path) {
 	return access(path, F_OK)==0;
+}
+int getFileMTime(char* path, time_t* out) {
+	if (!path || !out) return 0;
+	struct stat st;
+	if (stat(path, &st) != 0) return 0;
+	*out = st.st_mtime;
+	return 1;
 }
 void touch(char* path) {
 	close(open(path, O_RDWR|O_CREAT, 0777));

--- a/workspace/all/common/utils.h
+++ b/workspace/all/common/utils.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <time.h>
 
 int prefixMatch(char* pre, const char* str);
 int suffixMatch(char* suf,const char* str);
@@ -34,6 +35,7 @@ void trimTrailingNewlines(char* line);
 void trimSortingMeta(char** str);
 
 int exists(char* path);
+int getFileMTime(char* path, time_t* out);
 void touch(char* path);
 int toggle(char *path); // creates or removes file
 void putFile(char *path, char *contents);

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -5077,12 +5077,14 @@ static struct {
 	int slot;
 	int save_exists;
 	int preview_exists;
+	time_t save_mtime;
 } menu = {
 	.bitmap = NULL,
 	.disc = -1,
 	.total_discs = 0,
 	.save_exists = 0,
 	.preview_exists = 0,
+	.save_mtime = 0,
 	
 	.items = {
 		[ITEM_CONT] = "Continue",
@@ -6558,6 +6560,7 @@ static void Menu_initState(void) {
 	
 	menu.save_exists = 0;
 	menu.preview_exists = 0;
+	menu.save_mtime = 0;
 }
 static void Menu_updateState(void) {
 	// LOG_info("Menu_updateState\n");
@@ -6576,9 +6579,24 @@ static void Menu_updateState(void) {
 	
 	menu.save_exists = exists(save_path);
 	menu.preview_exists = menu.save_exists && exists(menu.bmp_path);
+	menu.save_mtime = 0;
+	if (menu.save_exists) {
+		time_t mtime = 0;
+		if (getFileMTime(save_path, &mtime)) {
+			menu.save_mtime = mtime;
+		}
+	}
 
 	// LOG_info("save_path: %s (%i)\n", save_path, menu.save_exists);
 	// LOG_info("bmp_path: %s txt_path: %s (%i)\n", menu.bmp_path, menu.txt_path, menu.preview_exists);
+}
+
+static int Menu_formatSaveTime(char *out, size_t out_size, time_t when) {
+	if (!out || out_size == 0 || when == 0) return 0;
+	struct tm tm = *localtime(&when);
+	if (CFG_getClock24H())
+		return strftime(out, out_size, "%Y-%m-%d %H:%M", &tm) > 0;
+	return strftime(out, out_size, "%Y-%m-%d %-I:%M %p", &tm) > 0;
 }
 
 typedef struct {
@@ -6999,6 +7017,31 @@ static void Menu_loop(void) {
 					else GFX_blitMessage(font.large, "Empty Slot", screen, &preview_rect);
 				}
 				
+				// save time overlay
+				if (menu.save_exists && menu.save_mtime) {
+					char save_time[32];
+					if (Menu_formatSaveTime(save_time, sizeof(save_time), menu.save_mtime)) {
+						int tw = 0;
+						int th = 0;
+						TTF_SizeUTF8(font.tiny, save_time, &tw, &th);
+						int pad_x = SCALE1(6);
+						int pad_y = SCALE1(4);
+						int pill_h = SCALE1(PILL_SIZE);
+						int pill_w = tw + pad_x * 2;
+						if (pill_w < pill_h) pill_w = pill_h;
+						int tx = ox + SCALE1(6);
+						int ty = oy + hh - pill_h - SCALE1(6);
+						GFX_blitPillLight(ASSET_WHITE_PILL, screen, &(SDL_Rect){tx, ty, pill_w, pill_h});
+						SDL_Surface* time_text = TTF_RenderUTF8_Blended(font.tiny, save_time, uintToColour(THEME_COLOR1_255));
+						if (time_text) {
+							SDL_BlitSurface(time_text, NULL, screen, &(SDL_Rect){
+								tx + (pill_w - time_text->w) / 2,
+								ty + (pill_h - time_text->h) / 2
+							});
+							SDL_FreeSurface(time_text);
+						}
+					}
+				}
 				// pagination
 				ox += (pw-SCALE1(15*MENU_SLOT_COUNT))/2;
 				oy += hh+SCALE1(WINDOW_RADIUS);


### PR DESCRIPTION
Often when I play and save, I miss being able to see the time of the saved slot. This PR adds a pill with the date over the preview image.

I don’t hide the fact that from start to finish (running it locally, making changes, and testing) I used AI, since I’m not proficient in C++, so I will accept a rejection with dignity. But who knows?

<img width="554" height="463" alt="image" src="https://github.com/user-attachments/assets/e85f3af7-4ca7-491f-b89e-6b9f840cbf33" />
