### PR TITLE
Save States: Improve compatibility with RetroArch savestates imported from other devices

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -992,7 +992,7 @@ static void State_read(void) { // from picoarch
 	}
 
 	if (!core.unserialize(state, state_size)) {
-	  LOG_error("Error restoring save state: %s (%s)\n", filename, strerror(errno));
+	  LOG_error("Error restoring save state: %s\n", filename);
 	  goto error;
 	}
 
@@ -1017,7 +1017,7 @@ error:
 	}
 
 	if (!core.unserialize(state, state_size)) {
-		LOG_error("Error restoring save state: %s (%s)\n", filename, strerror(errno));
+		LOG_error("Error restoring save state: %s\n", filename);
 		goto error;
 	}
 

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -976,49 +976,24 @@ static void State_read(void) { // from picoarch
 	RFILE *state_rfile = NULL;
 	rzipstream_t *state_rzfile = NULL;
 
-	// TODO: rzipstream_open can also handle uncompressed, else branch is probably unnecessary
-	// srm, potentially compressed
-	if (CFG_getStateFormat() == STATE_FORMAT_SRM || CFG_getStateFormat() == STATE_FORMAT_SRM_EXTRADOT) {
-		state_rzfile = rzipstream_open(filename, RETRO_VFS_FILE_ACCESS_READ);
-		if(!state_rzfile) {
-			if (state_slot!=8) { // st8 is a default state in MiniUI and may not exist, that's okay
-				LOG_error("Error opening state file: %s (%s)\n", filename, strerror(errno));
-			}
-			goto error;
-		}
-
-		// some cores report the wrong serialize size initially for some games, eg. mgba: Wario Land 4
-		// so we allow a size mismatch as long as the actual size fits in the buffer we've allocated
-		if (state_size < rzipstream_read(state_rzfile, state, state_size)) {
-			LOG_error("Error reading state data from file: %s (%s)\n", filename, strerror(errno));
-			goto error;
-		}
-
-		if (!core.unserialize(state, state_size)) {
-			LOG_error("Error restoring save state: %s (%s)\n", filename, strerror(errno));
-			goto error;
-		}
+	state_rzfile = rzipstream_open(filename, RETRO_VFS_FILE_ACCESS_READ);
+	if(!state_rzfile) {
+	  if (state_slot!=8) { // st8 is a default state in MiniUI and may not exist, that's okay
+		LOG_error("Error opening state file: %s (%s)\n", filename, strerror(errno));
+	  }
+	  goto error;
 	}
-	else {
-		state_rfile = filestream_open(filename, RETRO_VFS_FILE_ACCESS_READ, 0);
-		if (!state_rfile) {
-			if (state_slot!=8) { // st8 is a default state in MiniUI and may not exist, that's okay
-				LOG_error("Error opening state file: %s (%s)\n", filename, strerror(errno));
-			}
-			goto error;
-		}
-		
-		// some cores report the wrong serialize size initially for some games, eg. mgba: Wario Land 4
-		// so we allow a size mismatch as long as the actual size fits in the buffer we've allocated
-		if (state_size < filestream_read(state_rfile, state, state_size)) {
-			LOG_error("Error reading state data from file: %s (%s)\n", filename, strerror(errno));
-			goto error;
-		}
-	
-		if (!core.unserialize(state, state_size)) {
-			LOG_error("Error restoring save state: %s (%s)\n", filename, strerror(errno));
-			goto error;
-		}
+
+	// some cores report the wrong serialize size initially for some games, eg. mgba: Wario Land 4
+	// so we allow a size mismatch as long as the actual size fits in the buffer we've allocated
+	if (state_size < rzipstream_read(state_rzfile, state, state_size)) {
+	  LOG_error("Error reading state data from file: %s (%s)\n", filename, strerror(errno));
+	  goto error;
+	}
+
+	if (!core.unserialize(state, state_size)) {
+	  LOG_error("Error restoring save state: %s (%s)\n", filename, strerror(errno));
+	  goto error;
 	}
 
 error:


### PR DESCRIPTION

- Dedupe branch for compressed/uncompressed files (rzipstream already handles both)
- Check for RASTATE header; do not pass it to core.unserialize()

Addresses bug report by Discord user .mkchampion