### PR TITLE
Fix a few compile issues for x86-64 devices

### DIFF
--- a/workspace/all/common/generic_video.c
+++ b/workspace/all/common/generic_video.c
@@ -2114,9 +2114,7 @@ void PLAT_GL_Swap() {
 	//}
 }
 
-
-
-// tryin to some arm neon optimization for first time for flipping image upside down, they sit in platform cause not all have neon extensions
+// flipping image upside down
 void PLAT_pixelFlipper(uint8_t* pixels, int width, int height) {
     const int rowBytes = width * 4;
     uint8_t* rowTop;
@@ -2127,6 +2125,8 @@ void PLAT_pixelFlipper(uint8_t* pixels, int width, int height) {
         rowBottom = pixels + (height - 1 - y) * rowBytes;
 
         int x = 0;
+// NEON optimization for compatible ARM architectures
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
         for (; x + 15 < rowBytes; x += 16) {
             uint8x16_t top = vld1q_u8(rowTop + x);
             uint8x16_t bottom = vld1q_u8(rowBottom + x);
@@ -2134,6 +2134,7 @@ void PLAT_pixelFlipper(uint8_t* pixels, int width, int height) {
             vst1q_u8(rowTop + x, bottom);
             vst1q_u8(rowBottom + x, top);
         }
+#endif
         for (; x < rowBytes; ++x) {
             uint8_t temp = rowTop[x];
             rowTop[x] = rowBottom[x];

--- a/workspace/all/common/utils.c
+++ b/workspace/all/common/utils.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE // for strcasestr
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -4217,13 +4217,13 @@ void fillRect(int x, int y, int w, int h, uint32_t c, uint32_t *data, int stride
 }
 
 static void blitBitmapText(char* text, int ox, int oy, uint32_t* data, int stride, int width, int height) {
-	#define CHAR_WIDTH 5
-	#define CHAR_HEIGHT 9
+	#define DEBUG_CHAR_WIDTH 5
+	#define DEBUG_CHAR_HEIGHT 9
 	#define LETTERSPACING 1
 
 	int len = strlen(text);
-	int w = ((CHAR_WIDTH + LETTERSPACING) * len) - 1;
-	int h = CHAR_HEIGHT;
+	int w = ((DEBUG_CHAR_WIDTH + LETTERSPACING) * len) - 1;
+	int h = DEBUG_CHAR_HEIGHT;
 
 	if (ox < 0) ox = width - w + ox;
 	if (oy < 0) oy = height - h + oy;
@@ -4248,10 +4248,10 @@ static void blitBitmapText(char* text, int ox, int oy, uint32_t* data, int strid
 		for (int i = 0; i < len; i++) {
 			const char* c = bitmap_font[(unsigned char)text[i]];
 			if (!c) c = bitmap_font[' '];
-			for (int x = 0; x < CHAR_WIDTH; x++) {
+			for (int x = 0; x < DEBUG_CHAR_WIDTH; x++) {
 				if (current_x >= w) break;
 
-				if (c[y * CHAR_WIDTH + x] == '1') {
+				if (c[y * DEBUG_CHAR_WIDTH + x] == '1') {
 					data[y * stride + current_x] = 0xFFFFFFFF;  // white ARGBB8888
 				}
 				current_x++;

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -7,6 +7,7 @@ extern "C"
 #include "utils.h"
 }
 
+#include <csignal>
 #include <fstream>
 #include <sstream>
 #include <regex>


### PR DESCRIPTION
Fixes a few small issues I ran into compiling on an x86-64 platform

- NEON Compilation Error in the desktop platform.c fron non-arm-neon platfroms 
  - Added #if defined(__ARM_NEON) || defined(__ARM_NEON__) guard around NEON optimizations code block
- _GNU_SOURCE was unconditionally defined, causing potential redefinition conflicts
- Compilation errors on platforms where signal functions aren't implicitly declared
  - Added explicit #include \<csignal\>