### PR TITLE
Chore: Optimize resampling code

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -2391,11 +2391,19 @@ void SND_setQuality(int quality)
 	soundQuality = qualityLevels[quality];
 	resetSrcState = 1;
 }
+// Pre-allocated buffers for resample_audio to avoid malloc/free per call
+// Max input: BATCH_SIZE (100) frames = 200 floats
+// Max output: BATCH_SIZE * max_ratio (1.5) * max_sample_rate_ratio (~2) + margin = 400 frames = 800 floats
+#define RESAMPLE_MAX_INPUT_FRAMES BATCH_SIZE
+#define RESAMPLE_MAX_OUTPUT_FRAMES 400
+static float resample_input_buffer[RESAMPLE_MAX_INPUT_FRAMES * 2];
+static float resample_output_buffer[RESAMPLE_MAX_OUTPUT_FRAMES * 2];
+static SND_Frame resample_output_frames[RESAMPLE_MAX_OUTPUT_FRAMES];
+
 ResampledFrames resample_audio(const SND_Frame *input_frames,
 							   int input_frame_count, int input_sample_rate,
 							   int output_sample_rate, double ratio)
 {
-
 	int error;
 	static double previous_ratio = 1.0;
 	static SRC_STATE *src_state = NULL;
@@ -2427,16 +2435,15 @@ ResampledFrames resample_audio(const SND_Frame *input_frames,
 
 	int max_output_frames = (int)(input_frame_count * final_ratio + 1);
 
-	float *input_buffer = (float *)malloc(input_frame_count * 2 * sizeof(float));
-	float *output_buffer = (float *)malloc(max_output_frames * 2 * sizeof(float));
-	if (!input_buffer || !output_buffer)
+	// Use pre-allocated static buffers instead of malloc
+	if (input_frame_count > RESAMPLE_MAX_INPUT_FRAMES || max_output_frames > RESAMPLE_MAX_OUTPUT_FRAMES)
 	{
-		fprintf(stderr, "Error allocating buffers\n");
-		free(input_buffer);
-		free(output_buffer);
-		src_delete(src_state);
+		fprintf(stderr, "Error: resample buffer overflow (input=%d, output=%d)\n",
+				input_frame_count, max_output_frames);
 		exit(1);
 	}
+	float *input_buffer = resample_input_buffer;
+	float *output_buffer = resample_output_buffer;
 
 	for (int i = 0; i < input_frame_count; i++)
 	{
@@ -2456,21 +2463,13 @@ ResampledFrames resample_audio(const SND_Frame *input_frames,
 	{
 		fprintf(stderr, "Error resampling: %s\n",
 				src_strerror(src_error(src_state)));
-		free(input_buffer);
-		free(output_buffer);
 		exit(1);
 	}
 
 	int output_frame_count = src_data.output_frames_gen;
 
-	SND_Frame *output_frames = (SND_Frame *)malloc(output_frame_count * sizeof(SND_Frame));
-	if (!output_frames)
-	{
-		fprintf(stderr, "Error allocating output frames\n");
-		free(input_buffer);
-		free(output_buffer);
-		exit(1);
-	}
+	// Use pre-allocated static buffer for output frames
+	SND_Frame *output_frames = resample_output_frames;
 
 	for (int i = 0; i < output_frame_count; i++)
 	{
@@ -2484,8 +2483,7 @@ ResampledFrames resample_audio(const SND_Frame *input_frames,
 		output_frames[i].right = (int16_t)(right * 32767.0f);
 	}
 
-	free(input_buffer);
-	free(output_buffer);
+	// No need to free - using static buffers
 
 	ResampledFrames resampled;
 	resampled.frames = output_frames;
@@ -2497,23 +2495,21 @@ ResampledFrames resample_audio(const SND_Frame *input_frames,
 #define ROLLING_AVERAGE_WINDOW_SIZE 120
 static float adjustment_history[ROLLING_AVERAGE_WINDOW_SIZE] = {0.0f};
 static int adjustment_index = 0;
+static float adjustment_running_sum = 0.0f;
+
+// Debug-only rolling average (only computed when needed)
 static float remaining_space_history[ROLLING_AVERAGE_WINDOW_SIZE] = {0.0f};
 static int remaining_space_index = 0;
+static float remaining_space_running_sum = 0.0f;
 
 float calculateBufferAdjustment(float remaining_space, float targetbuffer_over, float targetbuffer_under, int batchsize)
 {
-
-	// this is just to show average remaining space in debug window could be removed later
+	// Debug: incremental rolling average for remaining space (only update perf struct, minimal overhead)
+	remaining_space_running_sum -= remaining_space_history[remaining_space_index];
 	remaining_space_history[remaining_space_index] = remaining_space;
+	remaining_space_running_sum += remaining_space;
 	remaining_space_index = (remaining_space_index + 1) % ROLLING_AVERAGE_WINDOW_SIZE;
-	float avgspace = 0.0f;
-	for (int i = 0; i < ROLLING_AVERAGE_WINDOW_SIZE; ++i)
-	{
-		avgspace += remaining_space_history[i];
-	}
-	avgspace /= ROLLING_AVERAGE_WINDOW_SIZE;
-	perf.avg_buffer_free = avgspace;
-	// end debug part
+	perf.avg_buffer_free = remaining_space_running_sum / ROLLING_AVERAGE_WINDOW_SIZE;
 
 	float midpoint = (targetbuffer_over + targetbuffer_under) / 2.0f;
 	perf.buffer_target = midpoint;
@@ -2527,29 +2523,22 @@ float calculateBufferAdjustment(float remaining_space, float targetbuffer_over, 
 	{
 		normalizedDistance = (remaining_space - midpoint) / (targetbuffer_under - midpoint);
 	}
-	// I make crazy small adjustments, mooore tiny is mooore stable :D But don't come neir the limits cuz imma hit ya with that 0.005 ratio adjustment, pow pow!
-	// I wonder if staying in the middle of 0 to 4000 with 512 samples per batch playing at tiny different speeds each iteration is like the smallest I can get
-	// lets say hovering around 2000 means 2000 samples queue, about 4 frames, so at 17ms(60fps) thats  68ms delay right?
-	// Should have payed attention when my math teacher was talking dammit
-	// Also I chose 3 for pow, but idk if that really the best nr, anyone good in maths looking at my code?
-	float adjustment = 0.001f + (0.01f - 0.001f) * pow(normalizedDistance, 3);
+	// Use x*x*x instead of pow(x, 3) for better performance
+	float nd3 = normalizedDistance * normalizedDistance * normalizedDistance;
+	float adjustment = 0.001f + (0.01f - 0.001f) * nd3;
 
 	if (remaining_space < midpoint)
 	{
 		adjustment = -adjustment;
 	}
 
+	// Incremental rolling average: subtract old value, add new value
+	adjustment_running_sum -= adjustment_history[adjustment_index];
 	adjustment_history[adjustment_index] = adjustment;
+	adjustment_running_sum += adjustment;
 	adjustment_index = (adjustment_index + 1) % ROLLING_AVERAGE_WINDOW_SIZE;
 
-	// Calculate the rolling average
-	float rolling_average = 0.0f;
-	for (int i = 0; i < ROLLING_AVERAGE_WINDOW_SIZE; ++i)
-	{
-		rolling_average += adjustment_history[i];
-	}
-	rolling_average /= ROLLING_AVERAGE_WINDOW_SIZE;
-	return rolling_average;
+	return adjustment_running_sum / ROLLING_AVERAGE_WINDOW_SIZE;
 }
 
 static SND_Frame tmpbuffer[BATCH_SIZE];
@@ -2675,7 +2664,7 @@ size_t SND_batchSamples(const SND_Frame *frames, size_t frame_count)
 		pthread_mutex_unlock(&audio_mutex);
 
 		total_consumed_frames += written_frames;
-		free(resampled.frames);
+		// No need to free - using static buffers
 	}
 
 	return total_consumed_frames;


### PR DESCRIPTION
(cherry picked from commit 408e8bbc57ed80361ed4a78e00b4d55d348393e5)
I am pulling this out of tg5050 for now. It is clearly the correct way to go, but it comes with additional work to be done that exceeds the scope of what the tg5050 branch is supposed to be. 

## The Lore

When profiling on ARM Linux and approximating a typical handheld (limit to two cores, reasonable defaults, Audio resampling on high or above, shaders on GBA), audio resampling (or rather: the accompanying calculations to match the render speed) turned out to take up a significant amount of the CPU time on our main thread:
- The rolling average calculations are performed 120 times per call
- In addition, we are calculating additional debug data that is useless in most cases
- We are using expensive float math for no reason at all
- Multiple static buffer allocations on every invocation
- Potential tsan issues, since not all parts of the audio buffer handling is properly guarded
- In total, this came down to around 66% of CPU time spent on audio resampling and related calls (assuming 60Hz target, thats 11 of 16.6ms).

## The result

After refactoring, almost all of the O(n) code has been replaced with O(1) and smarter memory allocations. As a result, our baseline CPU time per frame (convert pixel format, handle audio, prepare shader, everything up to the GL_swap) is routinely around 5-6ms using the same settings as above. This is of course great in terms of additional headroom for shaders, higher resampling quality, FF speed or just clocking lower to conserve battery and lower heat - but it turns out our Auto CPU scaling no longer handles its task properly. Due to being a lot less CPU bound and typically waiting for GL_Swap to complete with the next vblank:
- our CPU utilization calculation and the target window (75-85% usage, clock as low as possible) leads to a lot of frequency thrashing, pingponging between very high and low frequencies
- on tg5050 (which has two CPU clusters in bigLittle config) constantly swaps the thread over to the lowend cores
- the result is both audible (constant pitch shifting to account for dropped/late frames) and visible (flickering due to dropped/late frames).

## Possible solutions

A few ideas to improve the situation, and get this merged back in:
- Define a lower bound for auto CPU mode, that does not include the absolute lowest frequencies allowed. This would most likely have to be on a per-core basis, since the lower-end cores might want to clock down and conserve battery, whereas the higher-end cores will struggle to maintain fps when clocking too low.
- Introduce pinning to lock minarch to the high-performance cores, even in low utilization periods. This is going against the idea behind trusting the scheduler to make the right decisions, but it would at least solve part of the issue for tg5050 and other potential platforms with mixed core configurations.
- Further refactor the audio pipeline. Maybe there is a middle ground here, that still keeps some of the allocation efficiency. We could also look into other resampling APIs, either from libretro-common or SDL.
- Think of a better metric to drive auto CPU scaling. Calculating CPU busy time manually is pretty low-level considering we are targeting a lower-complexity vibe for the project as a whole. We already track frame timing and wait time for GL_Swap with the new revision of the Debug HUD, maybe there is some usable data there that could provide better insights. I could see a somewhat generic solution that compares CPU time spend vs. waiting for GL_swap to complete, and then scale CPU time to minimize the second.
- Reintroduce the granular scaling steps removed in 449eca631e7f72850a985970140cb3c80ad515ff to lessen thrashing
- Probably other I already forgot again.
