### PR TITLE
Fix: Paired Bluetooth devices not showing in bluetooth settings

### DIFF
--- a/workspace/all/settings/btmenu.cpp
+++ b/workspace/all/settings/btmenu.cpp
@@ -143,7 +143,7 @@ void Menu::updater()
             std::vector<BT_devicePaired> kl(SCAN_MAX_RESULTS);
             int known = BT_pairedDevices(kl.data(), SCAN_MAX_RESULTS);
             for (int i = 0; i < known; i++)
-                pairedMap.emplace(kl[i].remote_name, kl[i]);
+                pairedMap.emplace(kl[i].remote_addr, kl[i]);  // Use MAC address as key (unique)
 
             // grab list and compare it to previous result
             // only relayout the menu if changes happended


### PR DESCRIPTION
No devices shown in the bluetooth menu (Trimui Brick TG5040). But for paired device, it shows the bluetooth icon at the top (that mark a device is connected). Audio is playing via bluetooth device, but it was not listed in the device list. 

The problem is the code used `bluetoothctl paired-devices` which doesn't exist. The correct command is `bluetoothctl devices Paired`

Changes                                                                                                                                                                 
                                                                                                                                                                          
  - generic_bt.c: Use correct bluetoothctl devices Paired command                                                                                                         
  - generic_bt.c: Handle non-zero exit codes when output is still valid                                                                                                   
  - btmenu.cpp: Use MAC address as map key to prevent collisions with duplicate/empty device names 