### PR TITLE
Fix: Reduce render thread idle delay for smoother UI (~60fps)

### DIFF
--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -3304,7 +3304,7 @@ int main (int argc, char *argv[]) {
 				} 
 			}
 			else {
-				SDL_Delay(100); // why are we running long delays on the render thread, wtf?
+				SDL_Delay(16); // ~60fps instead of ~10fps
 			}
 			dirty = 0;
 		} 


### PR DESCRIPTION
## Summary

- Reduces `SDL_Delay(100)` to `SDL_Delay(16)` in the main render loop idle path (`nextui.c:3307`)
- Changes effective framerate from ~10fps to ~60fps when the UI is idle (no dirty flag)
- Single-line change with zero risk

## Context

The render thread's idle branch had a 100ms delay, making the game switcher and quick menu feel sluggish. Two identical `SDL_Delay(100)` calls at lines 1868 and 1908 were **already commented out** by the team, and the nearby else branch (line 3322) already uses `SDL_Delay(17)` — confirming 16-17ms is the intended frame timing.

This aligns with the existing inline comment: *"why are we running long delays on the render thread, wtf?"*

## Testing

- Running on a Trimui Brick (tg5040) since Feb 6, 2026 with no issues
- UI navigation is dramatically smoother
- No increase in CPU usage or heat (16ms is still a sleep, not a spin)