### PR TITLE
Adds visibility toggle for "Collections" in Appearance, Settings

### DIFF
--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -49,6 +49,7 @@ void CFG_defaults(NextUISettings *cfg)
         .showMenuTransitions = CFG_DEFAULT_SHOWMENUTRANSITIONS,
         .showRecents = CFG_DEFAULT_SHOWRECENTS,
         .showTools = CFG_DEFAULT_SHOWTOOLS,
+        .showCollections = CFG_DEFAULT_SHOWCOLLECTIONS,
         .showGameArt = CFG_DEFAULT_SHOWGAMEART,
         .gameSwitcherScaling = CFG_DEFAULT_GAMESWITCHERSCALING,
         .defaultView = CFG_DEFAULT_VIEW,
@@ -197,6 +198,11 @@ void CFG_init(FontLoad_callback_t cb, ColorSet_callback_t ccb)
             if (sscanf(line, "tools=%i", &temp_value) == 1)
             {
                 CFG_setShowTools((bool)temp_value);
+                continue;
+            }
+            if (sscanf(line, "collections=%i", &temp_value) == 1)
+            {
+                CFG_setShowCollections((bool)temp_value);
                 continue;
             }
             if (sscanf(line, "gameart=%i", &temp_value) == 1)
@@ -618,6 +624,17 @@ bool CFG_getShowTools(void)
 void CFG_setShowTools(bool show)
 {
     settings.showTools = show;
+    CFG_sync();
+}
+
+bool CFG_getShowCollections(void)
+{
+    return settings.showCollections;
+}
+
+void CFG_setShowCollections(bool show)
+{
+    settings.showCollections = show;
     CFG_sync();
 }
 
@@ -1065,6 +1082,10 @@ void CFG_get(const char *key, char *value)
     {
         sprintf(value, "%i", CFG_getShowTools());
     }
+	else if (strcmp(key, "collections") == 0)
+	{
+		sprintf(value, "%i", CFG_getShowCollections());
+    }
     else if (strcmp(key, "gameart") == 0)
     {
         sprintf(value, "%i", CFG_getShowGameArt());
@@ -1199,6 +1220,7 @@ void CFG_sync(void)
     fprintf(file, "menutransitions=%i\n", settings.showMenuTransitions);
     fprintf(file, "recents=%i\n", settings.showRecents);
     fprintf(file, "tools=%i\n", settings.showTools);
+	fprintf(file, "collections=%i\n", settings.showCollections);
     fprintf(file, "gameart=%i\n", settings.showGameArt);
     fprintf(file, "showfoldernamesatroot=%i\n", settings.showFolderNamesAtRoot);
     fprintf(file, "screentimeout=%i\n", settings.screenTimeoutSecs);
@@ -1259,6 +1281,7 @@ void CFG_print(void)
     printf("\t\"menutransitions\": %i,\n", settings.showMenuTransitions);
     printf("\t\"recents\": %i,\n", settings.showRecents);
     printf("\t\"tools\": %i,\n", settings.showTools);
+	printf("\t\"collections\": %i,\n", settings.showCollections);
     printf("\t\"gameart\": %i,\n", settings.showGameArt);
     printf("\t\"showfoldernamesatroot\": %i,\n", settings.showFolderNamesAtRoot);
     printf("\t\"screentimeout\": %i,\n", settings.screenTimeoutSecs);

--- a/workspace/all/common/config.h
+++ b/workspace/all/common/config.h
@@ -100,6 +100,7 @@ typedef struct
 	bool showMenuTransitions;
 	bool showRecents;
 	bool showTools;
+	bool showCollections;
 	bool showGameArt;
 	bool showFolderNamesAtRoot;
 	bool romsUseFolderBackground;
@@ -167,6 +168,7 @@ typedef struct
 #define CFG_DEFAULT_SHOWMENUANIMATIONS true
 #define CFG_DEFAULT_SHOWMENUTRANSITIONS true
 #define CFG_DEFAULT_SHOWRECENTS true
+#define CFG_DEFAULT_SHOWCOLLECTIONS true
 #define CFG_DEFAULT_SHOWGAMEART true
 #define CFG_DEFAULT_SHOWFOLDERNAMESATROOT true
 #define CFG_DEFAULT_GAMESWITCHERSCALING GFX_SCALE_FULLSCREEN
@@ -259,6 +261,9 @@ void CFG_setShowRecents(bool show);
 // Show/hide tools folder in the main menu.
 bool CFG_getShowTools(void);
 void CFG_setShowTools(bool show);
+// Show/hide collections in the main menu.
+bool CFG_getShowCollections(void);
+void CFG_setShowCollections(bool show);
 // Show/hide game art in the main menu.
 bool CFG_getShowGameArt(void);
 void CFG_setShowGameArt(bool show);

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -860,7 +860,7 @@ static Array* getRoot(void) {
 	Array *entries = getRoms();
 
 	// Handle collections
-    if (hasCollections()) {
+	if (hasCollections() && CFG_getShowCollections()) {
         if (entries->count) {
             Array_push(root, Entry_new(COLLECTIONS_PATH, ENTRY_DIR));
         } else { // No visible systems, promote collections to root

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -255,6 +255,10 @@ int main(int argc, char *argv[])
                 []() -> std::any { return CFG_getShowTools(); },
                 [](const std::any &value) { CFG_setShowTools(std::any_cast<bool>(value)); },
                 []() { CFG_setShowTools(CFG_DEFAULT_SHOWTOOLS);}},
+                new MenuItem{ListItemType::Generic, "Show Collections", "Show \"Collections\" menu entry in game list.", {false, true}, on_off, 
+                []() -> std::any { return CFG_getShowCollections(); },
+                [](const std::any &value) { CFG_setShowCollections(std::any_cast<bool>(value)); },
+                []() { CFG_setShowCollections(CFG_DEFAULT_SHOWCOLLECTIONS);}},
                 new MenuItem{ListItemType::Generic, "Show game art", "Show game artwork in the main menu", {false, true}, on_off, []() -> std::any
                 { return CFG_getShowGameArt(); },
                 [](const std::any &value)


### PR DESCRIPTION
As requested by dantist (agreed by me also, who never uses collections), it introduces a new setting to control the visibility of the "Collections" entry in the main menu.