### PR TITLE
Add shortcut to automatically cycle through slots on save state

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -2357,7 +2357,8 @@ enum {
 	SHORTCUT_TOGGLE_TURBO_L2,
 	SHORTCUT_TOGGLE_TURBO_R,
 	SHORTCUT_TOGGLE_TURBO_R2,
-	// 
+	//
+	SHORTCUT_CYCLE_SAVE_STATE,
 	SHORTCUT_COUNT,
 };
 
@@ -2976,6 +2977,7 @@ static struct Config {
 		[SHORTCUT_TOGGLE_TURBO_R]		= {"Toggle Turbo R",	-1, BTN_ID_NONE, 0},
 		[SHORTCUT_TOGGLE_TURBO_R2]		= {"Toggle Turbo R2",	-1, BTN_ID_NONE, 0},
 		// -----
+		[SHORTCUT_CYCLE_SAVE_STATE]		= {"Cycle & Save State",-1, BTN_ID_NONE, 0},
 		{NULL}
 	},
 };
@@ -4211,6 +4213,7 @@ static void Menu_screenshot(void);
 
 static void Menu_saveState(void);
 static void Menu_loadState(void);
+static void Menu_cycleSaveState(void);
 
 static int setFastForward(int enable) {
 	int val = enable ? 1 : 0;
@@ -4348,9 +4351,13 @@ static void input_poll_callback(void) {
 			}
 			else if (PAD_justPressed(btn)) {
 				switch (i) {
-					case SHORTCUT_SAVE_STATE: 
+					case SHORTCUT_SAVE_STATE:
 						newScreenshot = 1;
-						Menu_saveState(); 
+						Menu_saveState();
+						break;
+					case SHORTCUT_CYCLE_SAVE_STATE:
+						newScreenshot = 1;
+						Menu_cycleSaveState();
 						break;
 					case SHORTCUT_LOAD_STATE: Menu_loadState(); break;
 					case SHORTCUT_SCREENSHOT:
@@ -8468,6 +8475,11 @@ static void Menu_loadState(void) {
 			Notification_push(NOTIFICATION_LOAD_STATE, msg, NULL);
 		}
 	}
+}
+
+static void Menu_cycleSaveState(void) {
+	menu.slot = (menu.slot + 1) % MENU_SLOT_COUNT;
+	Menu_saveState();
 }
 
 static void Menu_loop(void) {


### PR DESCRIPTION
Hi! I'm a big fan and user of NextUI, and I've been wanting this feature for a while - and apparently others too as I can see in #203 

This felt to me like the least invasive change: instead of a config change, I'm adding an add'l shortcut that simultaneously cycles through slots and saves the state. 

Feel free to merge if this makes sense, I can also try and address any feedback in a timely manner (although I'm not very well versed and might need some pointers). If you don't like it, feel free to reject/close, I won't take it personally :)

Cheers, and thanks for all the hard work on this project!