### PR TITLE
feat: SRAM_read - attempt to load save files regardless of user compression setting

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -830,14 +830,14 @@ static void SRAM_read(void) {
 	if(!sram_file) return;
 
 	if (!sram || rzipstream_read(sram_file, sram, sram_size) < 0)
-	  LOG_error("rzipstream: Error reading SRAM data\n");
+		LOG_error("rzipstream: Error reading SRAM data\n");
 		
 	rzipstream_close(sram_file);
 #else 
 	FILE *sram_file = fopen(filename, "r");
 	if (!sram_file) return;
 	if (!sram || !fread(sram, 1, sram_size, sram_file)) {
-	  LOG_error("Error reading SRAM data\n");
+		LOG_error("Error reading SRAM data\n");
 	}
 	fclose(sram_file);
 #endif


### PR DESCRIPTION
Patching SRAM_read to match the behaviour of save state loading. regardless of whether a save file is compressed or raw, continue loading it even it doesn't match the user setting.

(libretro code already does the proper branching for us)