### PR TITLE
feat: load shader parameter values from .cfg preset files

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -6979,8 +6979,11 @@ static int OptionShaders_optionChanged(MenuList* list, int i) {
 		initShaders();
 
 		// Now that we have a list of shader parameters,
-		// re-read shader preset file to set pragma values
+		// re-read shader preset file to set pragma values in-menu
 		Config_syncShaders(item->key, item->value);
+
+		// Push parameters to shader engine
+		applyShaderSettings();
 	}
 	return MENU_CALLBACK_NOP;
 }


### PR DESCRIPTION
Addresses #685 

Minarch will now check for any shader parameters when loading a .cfg preset.

Use cases include:
- user wants to have multiple sets of default settings for a shader, for example, different cores
- shader dev wants to go back-and-forth between two configurations

(edit: btw, changes are fully orthogonal to my other shader-related PR)