### PR TITLE
Fix badge download cap at 256 preventing large achievement sets from fully downloading

### DIFF
--- a/workspace/all/common/ra_badges.c
+++ b/workspace/all/common/ra_badges.c
@@ -24,9 +24,8 @@
 
 #define RA_BADGE_BASE_URL "https://media.retroachievements.org/Badge/"
 #define MAX_BADGE_NAME 32
-#define MAX_CACHED_BADGES 256
+#define MAX_CACHED_BADGES 2048
 #define MAX_CONCURRENT_DOWNLOADS 8
-#define MAX_QUEUED_DOWNLOADS 512
 #define NOTIFICATION_TIMEOUT_MS 15000
 
 /*****************************************************************************
@@ -63,7 +62,7 @@ static uint32_t notification_start_time = 0;
 
 // Download queue for rate limiting
 typedef struct {
-	QueuedDownload items[MAX_QUEUED_DOWNLOADS];
+	QueuedDownload items[MAX_CACHED_BADGES];
 	int head;
 	int tail;
 	int count;
@@ -196,7 +195,7 @@ static void badge_download_callback(HTTP_Response* response, void* userdata);
 
 // Queue a download for later processing (must hold mutex)
 static void queue_download(const char* badge_name, bool locked) {
-	if (download_queue.count >= MAX_QUEUED_DOWNLOADS) {
+	if (download_queue.count >= MAX_CACHED_BADGES) {
 		BADGE_LOG_WARN("Download queue full, dropping badge %s\n", badge_name);
 		return;
 	}
@@ -206,7 +205,7 @@ static void queue_download(const char* badge_name, bool locked) {
 	item->badge_name[MAX_BADGE_NAME - 1] = '\0';
 	item->locked = locked;
 	
-	download_queue.tail = (download_queue.tail + 1) % MAX_QUEUED_DOWNLOADS;
+	download_queue.tail = (download_queue.tail + 1) % MAX_CACHED_BADGES;
 	download_queue.count++;
 }
 
@@ -215,7 +214,7 @@ static bool dequeue_and_start_download(void) {
 	if (download_queue.count == 0) return false;
 	
 	QueuedDownload* item = &download_queue.items[download_queue.head];
-	download_queue.head = (download_queue.head + 1) % MAX_QUEUED_DOWNLOADS;
+	download_queue.head = (download_queue.head + 1) % MAX_CACHED_BADGES;
 	download_queue.count--;
 	
 	// Get entry and check if still needs download


### PR DESCRIPTION
Summary

- Fixes badge images not downloading for games with large achievement sets (e.g. Pokemon Unbound being the largest with 844 achievements)
- `MAX_CACHED_BADGES` was hardcoded to 256, but both locked and unlocked badge variants are cached per achievement, so any game with more than 128 achievements would silently drop badges
- Increased limit from 256 to 2048 (supports up to 1,024 achievements), at a cost of ~184 KB of static memory on AArch64
- Removed the redundant `MAX_QUEUED_DOWNLOADS` constant — the download queue and badge cache are structurally coupled and must always be the same size, so both now use `MAX_CACHED_BADGES`