### PR TITLE
fix: memory leak in resampler

### DIFF
--- a/workspace/all/common/api.c
+++ b/workspace/all/common/api.c
@@ -2760,7 +2760,7 @@ size_t SND_batchSamples_fixed_rate(const SND_Frame *frames, size_t frame_count)
 		pthread_mutex_unlock(&audio_mutex);
 
 		total_consumed_frames += written_frames;
-		// No need to free - using static buffers
+		free(resampled.frames);
 	}
 
 	return total_consumed_frames;


### PR DESCRIPTION
The bug sneaked in as part of PR #573 which did have static buffers, but was reverted. Only this line seems to have sneaked in. Current main branch does not have static buffers in the resample_audio() function. Check issue #696  for details.