### PR TITLE
fix: handle RETRO_ENVIRONMENT_SHUTDOWN in Minarch

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -4514,6 +4514,11 @@ static bool environment_callback(unsigned cmd, void *data) { // copied from pico
 		if (message) LOG_info("%s\n", message->msg);
 		break;
 	}
+	case RETRO_ENVIRONMENT_SHUTDOWN: { /* 7 */
+		LOG_info("Core requested shutdown\n");
+		quit = 1;
+		break;
+	}
 	case RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL: { /* 8 */
 		// puts("RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL");
 		// TODO: used by fceumm at least


### PR DESCRIPTION
## Summary

- Minarch's environment callback had no handler for `RETRO_ENVIRONMENT_SHUTDOWN` (cmd 7), causing cores with built-in quit menus (e.g. PRBoom/Doom) to freeze the frontend instead of exiting cleanly
- When a core requests shutdown, Minarch now sets `quit = 1`, using the same exit path as its own menu quit