### PR TITLE
New transition animation with snappy and comfy speeds

### DIFF
--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -633,12 +633,17 @@ void PLAT_animateSurface(
 	int target_opacity,
 	int layer
 );
+#define ANIM_LINEAR   0
+#define ANIM_EASE_OUT 1  // cubic ease-out: fast start, slows to stop
+#define ANIM_EASE_IN  2  // cubic ease-in: slow start, fast exit
+
 void PLAT_animateAndFadeSurface(
 	SDL_Surface *inputSurface,
 	int x, int y, int target_x, int target_y, int w, int h, int duration_ms,
 	SDL_Surface *fadeSurface,
-	int fade_x, int fade_y, int fade_w, int fade_h,
-	int start_opacity, int target_opacity, int layer
+	int fade_x, int fade_y, int fade_target_x, int fade_target_y, int fade_w, int fade_h,
+	int start_opacity, int target_opacity, int layer,
+	int input_easing, int fade_easing
 );
 
 void PLAT_animateSurfaceOpacity(SDL_Surface *inputSurface, int x, int y, int w, int h,

--- a/workspace/all/common/api.h
+++ b/workspace/all/common/api.h
@@ -633,9 +633,10 @@ void PLAT_animateSurface(
 	int target_opacity,
 	int layer
 );
-#define ANIM_LINEAR   0
-#define ANIM_EASE_OUT 1  // cubic ease-out: fast start, slows to stop
-#define ANIM_EASE_IN  2  // cubic ease-in: slow start, fast exit
+#define ANIM_LINEAR      0
+#define ANIM_EASE_OUT    1  // fast start, slows to stop
+#define ANIM_EASE_IN     2  // slow start, fast exit
+#define ANIM_EASE_IN_OUT 3  // slow start, fast middle, slow end
 
 void PLAT_animateAndFadeSurface(
 	SDL_Surface *inputSurface,
@@ -643,7 +644,7 @@ void PLAT_animateAndFadeSurface(
 	SDL_Surface *fadeSurface,
 	int fade_x, int fade_y, int fade_target_x, int fade_target_y, int fade_w, int fade_h,
 	int start_opacity, int target_opacity, int layer,
-	int input_easing, int fade_easing
+	int input_easing, int fade_easing, int intensity
 );
 
 void PLAT_animateSurfaceOpacity(SDL_Surface *inputSurface, int x, int y, int w, int h,

--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -91,6 +91,7 @@ void CFG_defaults(NextUISettings *cfg)
         .raNotificationDuration = CFG_DEFAULT_RA_NOTIFICATION_DURATION,
         .raProgressNotificationDuration = CFG_DEFAULT_RA_PROGRESS_NOTIFICATION_DURATION,
         .raAchievementSortOrder = CFG_DEFAULT_RA_ACHIEVEMENT_SORT_ORDER,
+
 };
 
     *cfg = defaults;
@@ -187,7 +188,8 @@ void CFG_init(FontLoad_callback_t cb, ColorSet_callback_t ccb)
             }
             if (sscanf(line, "menutransitions=%i", &temp_value) == 1)
             {
-                CFG_setMenuTransitions((bool)temp_value);
+                // Old bool values (0/1) map directly: 0=off, 1=snappy.
+                CFG_setMenuTransitions(temp_value);
                 continue;
             }
             if (sscanf(line, "recents=%i", &temp_value) == 1)
@@ -583,14 +585,14 @@ void CFG_setMenuAnimations(bool show)
     CFG_sync();
 }
 
-bool CFG_getMenuTransitions(void)
+int CFG_getMenuTransitions(void)
 {
     return settings.showMenuTransitions;
 }
 
-void CFG_setMenuTransitions(bool show)
+void CFG_setMenuTransitions(int mode)
 {
-    settings.showMenuTransitions = show;
+    settings.showMenuTransitions = mode;
     CFG_sync();
 }
 

--- a/workspace/all/common/config.h
+++ b/workspace/all/common/config.h
@@ -108,7 +108,7 @@ typedef struct
 	bool clock24h;
 	bool showBatteryPercent;
 	bool showMenuAnimations;
-	bool showMenuTransitions;
+	int showMenuTransitions; // 0=off, 1=snappy, 2=comfy
 	bool showRecents;
 	bool showTools;
 	bool showCollections;
@@ -133,7 +133,7 @@ typedef struct
 
 	// Haptic
 	bool haptics;
-	
+
 	// Networking
 	bool ntp;
 	int currentTimezone; // index of timezone in tz database
@@ -164,6 +164,11 @@ typedef struct
 
 } NextUISettings;
 
+// Transition mode constants
+#define TRANSITION_OFF    0
+#define TRANSITION_SNAPPY 1
+#define TRANSITION_COMFY  2
+
 #define CFG_DEFAULT_FONT_ID 1  // Next
 #define CFG_DEFAULT_COLOR1 0xffffffU
 #define CFG_DEFAULT_COLOR2 0x9b2257U
@@ -184,7 +189,7 @@ typedef struct
 #define CFG_DEFAULT_CLOCK24H true
 #define CFG_DEFAULT_SHOWBATTERYPERCENT false
 #define CFG_DEFAULT_SHOWMENUANIMATIONS true
-#define CFG_DEFAULT_SHOWMENUTRANSITIONS true
+#define CFG_DEFAULT_SHOWMENUTRANSITIONS TRANSITION_SNAPPY
 #define CFG_DEFAULT_SHOWRECENTS true
 #define CFG_DEFAULT_SHOWCOLLECTIONS true
 #define CFG_DEFAULT_SHOWGAMEART true
@@ -230,6 +235,12 @@ typedef struct
 #define CFG_DEFAULT_RA_PROGRESS_NOTIFICATION_DURATION 1
 #define CFG_DEFAULT_RA_ACHIEVEMENT_SORT_ORDER RA_SORT_UNLOCKED_FIRST
 
+// Transition animation parameters (fixed per mode)
+#define TRANSITION_SNAPPY_DURATION  150
+#define TRANSITION_COMFY_DURATION   250
+#define TRANSITION_CURVE            1   // ANIM_EASE_OUT
+#define TRANSITION_INTENSITY        3
+
 void CFG_init(FontLoad_callback_t fontCallback, ColorSet_callback_t ccb);
 void CFG_print(void);
 void CFG_get(const char *key, char * value);
@@ -267,9 +278,9 @@ void CFG_setShowBatteryPercent(bool show);
 // Show/hide menu animations in main menu.
 bool CFG_getMenuAnimations(void);
 void CFG_setMenuAnimations(bool show);
-// Show/hide menu transitions between screens in main menu.
-bool CFG_getMenuTransitions(void);
-void CFG_setMenuTransitions(bool show);
+// Menu transition mode: TRANSITION_OFF, TRANSITION_SNAPPY, TRANSITION_COMFY.
+int CFG_getMenuTransitions(void);
+void CFG_setMenuTransitions(int mode);
 // Set thumbnail rounding radius.
 int CFG_getThumbnailRadius(void);
 void CFG_setThumbnailRadius(int radius);

--- a/workspace/all/common/generic_video.c
+++ b/workspace/all/common/generic_video.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <stdint.h>
+#include <math.h>
 
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
@@ -1397,12 +1398,24 @@ SDL_Surface* PLAT_captureRendererToSurface() {
 	return surface;
 }
 
+static float anim_ease(float t, int easing) {
+	switch (easing) {
+		case ANIM_EASE_OUT:
+			return 1.0f - powf(1.0f - t, 2.0f);
+		case ANIM_EASE_IN:
+			return t * t * t;
+		default:
+			return t;
+	}
+}
+
 void PLAT_animateAndFadeSurface(
 	SDL_Surface *inputSurface,
 	int x, int y, int target_x, int target_y, int w, int h, int duration_ms,
 	SDL_Surface *fadeSurface,
-	int fade_x, int fade_y, int fade_w, int fade_h,
-	int start_opacity, int target_opacity,int layer
+	int fade_x, int fade_y, int fade_target_x, int fade_target_y, int fade_w, int fade_h,
+	int start_opacity, int target_opacity, int layer,
+	int input_easing, int fade_easing
 ) {
 	if (!inputSurface || !vid.renderer) return;
 
@@ -1438,9 +1451,11 @@ void PLAT_animateAndFadeSurface(
 	for (int frame = 0; frame <= total_frames; ++frame) {
 
 		float t = (float)frame / total_frames;
+		float t_input = anim_ease(t, input_easing);
+		float t_fade  = anim_ease(t, fade_easing);
 
-		int current_x = x + (int)((target_x - x) * t);
-		int current_y = y + (int)((target_y - y) * t);
+		int current_x = x + (int)((target_x - x) * t_input);
+		int current_y = y + (int)((target_y - y) * t_input);
 
 		int current_opacity = start_opacity + (int)((target_opacity - start_opacity) * t);
 		if (current_opacity < 0) current_opacity = 0;
@@ -1476,7 +1491,9 @@ void PLAT_animateAndFadeSurface(
 
 		if (fadeTexture) {
 			SDL_SetTextureAlphaMod(fadeTexture, current_opacity);
-			SDL_Rect fadeDstRect = { fade_x, fade_y, fade_w, fade_h };
+			int fade_current_x = fade_x + (int)((fade_target_x - fade_x) * t_fade);
+			int fade_current_y = fade_y + (int)((fade_target_y - fade_y) * t_fade);
+			SDL_Rect fadeDstRect = { fade_current_x, fade_current_y, fade_w, fade_h };
 			SDL_RenderCopy(vid.renderer, fadeTexture, NULL, &fadeDstRect);
 		}
 

--- a/workspace/all/common/generic_video.c
+++ b/workspace/all/common/generic_video.c
@@ -1398,12 +1398,16 @@ SDL_Surface* PLAT_captureRendererToSurface() {
 	return surface;
 }
 
-static float anim_ease(float t, int easing) {
+static float anim_ease(float t, int easing, float intensity) {
 	switch (easing) {
 		case ANIM_EASE_OUT:
-			return 1.0f - powf(1.0f - t, 2.0f);
+			return 1.0f - powf(1.0f - t, intensity);
 		case ANIM_EASE_IN:
-			return t * t * t;
+			return powf(t, intensity);
+		case ANIM_EASE_IN_OUT:
+			return t < 0.5f
+				? 0.5f * powf(2.0f * t, intensity)
+				: 1.0f - 0.5f * powf(2.0f * (1.0f - t), intensity);
 		default:
 			return t;
 	}
@@ -1415,7 +1419,7 @@ void PLAT_animateAndFadeSurface(
 	SDL_Surface *fadeSurface,
 	int fade_x, int fade_y, int fade_target_x, int fade_target_y, int fade_w, int fade_h,
 	int start_opacity, int target_opacity, int layer,
-	int input_easing, int fade_easing
+	int input_easing, int fade_easing, int intensity
 ) {
 	if (!inputSurface || !vid.renderer) return;
 
@@ -1451,8 +1455,8 @@ void PLAT_animateAndFadeSurface(
 	for (int frame = 0; frame <= total_frames; ++frame) {
 
 		float t = (float)frame / total_frames;
-		float t_input = anim_ease(t, input_easing);
-		float t_fade  = anim_ease(t, fade_easing);
+		float t_input = anim_ease(t, input_easing, (float)intensity);
+		float t_fade  = anim_ease(t, fade_easing, (float)intensity);
 
 		int current_x = x + (int)((target_x - x) * t_input);
 		int current_y = y + (int)((target_y - y) * t_input);

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -3141,8 +3141,8 @@ int main (int argc, char *argv[]) {
 					SDL_Surface *tmpNewScreen = GFX_captureRendererToSurface();
 					SDL_SetSurfaceBlendMode(tmpNewScreen,SDL_BLENDMODE_BLEND);
 					GFX_clearLayers(LAYER_THUMBNAIL);
-					if(animationdirection == SLIDE_LEFT) GFX_animateAndFadeSurface(tmpOldScreen,0,0,0-FIXED_WIDTH,0,FIXED_WIDTH,FIXED_HEIGHT,200,tmpNewScreen,1,0,FIXED_WIDTH,FIXED_HEIGHT,0,255,LAYER_THUMBNAIL);
-					if(animationdirection == SLIDE_RIGHT) GFX_animateAndFadeSurface(tmpOldScreen,0,0,0+FIXED_WIDTH,0,FIXED_WIDTH,FIXED_HEIGHT,200,tmpNewScreen,1,0,FIXED_WIDTH,FIXED_HEIGHT,0,255,LAYER_THUMBNAIL);
+					if(animationdirection == SLIDE_LEFT) GFX_animateAndFadeSurface(tmpOldScreen,0,0,-250,0,FIXED_WIDTH,FIXED_HEIGHT,200,tmpNewScreen,FIXED_WIDTH,0,0,0,FIXED_WIDTH,FIXED_HEIGHT,255,255,LAYER_THUMBNAIL,ANIM_EASE_OUT,ANIM_EASE_OUT);
+					if(animationdirection == SLIDE_RIGHT) GFX_animateAndFadeSurface(tmpNewScreen,-250,0,0,0,FIXED_WIDTH,FIXED_HEIGHT,200,tmpOldScreen,0,0,FIXED_WIDTH,0,FIXED_WIDTH,FIXED_HEIGHT,255,255,LAYER_THUMBNAIL,ANIM_EASE_OUT,ANIM_EASE_OUT);
 					GFX_clearLayers(LAYER_THUMBNAIL);
 					SDL_FreeSurface(tmpNewScreen);
 				}

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -3137,12 +3137,29 @@ int main (int argc, char *argv[]) {
 					SDL_UnlockMutex(bgMutex);
 					folderbgchanged = 1;
 					GFX_clearLayers(LAYER_TRANSITION);
+					// Draw the selection pill at its target position before capturing the new
+					// screen, so the cursor is present in the incoming slide surface rather than
+					// blinking in after the transition animation ends.
+					if (currentScreen == SCREEN_GAMELIST && total > 0 && globalpill && list_show_entry_names) {
+						SDL_LockMutex(animMutex);
+						GFX_drawOnLayer(globalpill, SCALE1(BUTTON_MARGIN), (int)SCALE1(targetY + PADDING), globallpillW, globalpill->h, 1.0f, 0, LAYER_TRANSITION);
+						if (globalText) {
+							GFX_drawOnLayer(globalText, SCALE1(BUTTON_MARGIN + BUTTON_PADDING), pilltargetTextY, globalText->w, globalText->h, 1.0f, 0, LAYER_SCROLLTEXT);
+						}
+						SDL_UnlockMutex(animMutex);
+					}
 					GFX_flipHidden();
 					SDL_Surface *tmpNewScreen = GFX_captureRendererToSurface();
 					SDL_SetSurfaceBlendMode(tmpNewScreen,SDL_BLENDMODE_BLEND);
+					GFX_clearLayers(LAYER_SCROLLTEXT); // baked into tmpNewScreen; must clear or it floats above the animation
 					GFX_clearLayers(LAYER_THUMBNAIL);
-					if(animationdirection == SLIDE_LEFT) GFX_animateAndFadeSurface(tmpOldScreen,0,0,-250,0,FIXED_WIDTH,FIXED_HEIGHT,200,tmpNewScreen,FIXED_WIDTH,0,0,0,FIXED_WIDTH,FIXED_HEIGHT,255,255,LAYER_THUMBNAIL,ANIM_EASE_OUT,ANIM_EASE_OUT);
-					if(animationdirection == SLIDE_RIGHT) GFX_animateAndFadeSurface(tmpNewScreen,-250,0,0,0,FIXED_WIDTH,FIXED_HEIGHT,200,tmpOldScreen,0,0,FIXED_WIDTH,0,FIXED_WIDTH,FIXED_HEIGHT,255,255,LAYER_THUMBNAIL,ANIM_EASE_OUT,ANIM_EASE_OUT);
+					{
+						int _duration = (CFG_getMenuTransitions() == TRANSITION_COMFY)
+							? TRANSITION_COMFY_DURATION
+							: TRANSITION_SNAPPY_DURATION;
+						if(animationdirection == SLIDE_LEFT) GFX_animateAndFadeSurface(tmpOldScreen,0,0,-250,0,FIXED_WIDTH,FIXED_HEIGHT,_duration,tmpNewScreen,FIXED_WIDTH,0,0,0,FIXED_WIDTH,FIXED_HEIGHT,255,255,LAYER_THUMBNAIL,TRANSITION_CURVE,TRANSITION_CURVE,TRANSITION_INTENSITY);
+						if(animationdirection == SLIDE_RIGHT) GFX_animateAndFadeSurface(tmpNewScreen,-250,0,0,0,FIXED_WIDTH,FIXED_HEIGHT,_duration,tmpOldScreen,0,0,FIXED_WIDTH,0,FIXED_WIDTH,FIXED_HEIGHT,255,255,LAYER_THUMBNAIL,TRANSITION_CURVE,TRANSITION_CURVE,TRANSITION_INTENSITY);
+					}
 					GFX_clearLayers(LAYER_THUMBNAIL);
 					SDL_FreeSurface(tmpNewScreen);
 				}

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -50,7 +50,7 @@ struct Context
     int show_setting;
 
     // Either the app manages these, or we account for the space and let the menu draw it
-    // We could hardcode the behavior down below, but this should also serve as demo code 
+    // We could hardcode the behavior down below, but this should also serve as demo code
     // for how to use menu.cpp in different ways depending on the needs of the app
     bool appManagesTitle = false;
     bool appManagesIndicator = true;
@@ -101,6 +101,10 @@ static const std::vector<std::string> notify_duration_labels = {"1s", "2s", "3s"
 // Progress notification duration options (in seconds, 0 = disabled)
 static const std::vector<std::any> progress_duration_values = {0, 1, 2, 3, 4, 5};
 static const std::vector<std::string> progress_duration_labels = {"Off", "1s", "2s", "3s", "4s", "5s"};
+
+// Menu transition mode options
+static const std::vector<std::any>    transition_mode_values = {(int)TRANSITION_OFF, (int)TRANSITION_SNAPPY, (int)TRANSITION_COMFY};
+static const std::vector<std::string> transition_mode_labels = {"Off", "Snappy", "Comfy"};
 
 // RetroAchievements sort order options
 static const std::vector<std::any> ra_sort_values = {
@@ -255,11 +259,11 @@ namespace {
         bool hasWifi() const {
             return m_platform == tg5050 || m_platform == tg5040 || m_platform == my355;
         }
-        
+
         bool hasBluetooth() const {
             return m_platform == tg5050 || m_platform == tg5040 || m_platform == my355;
         }
-    
+
     private:
         Vendor m_vendor = Unknown;
         Model m_model = UnknownModel;
@@ -296,7 +300,7 @@ int main(int argc, char *argv[])
 
         int was_online = PWR_isOnline();
         int had_bt = PLAT_btIsConnected();
-        
+
         std::vector<std::any> tz_values;
         std::vector<std::string> tz_labels;
         for (int i = 0; i < tz_count; ++i) {
@@ -360,10 +364,10 @@ int main(int argc, char *argv[])
             []() -> std::any{ return CFG_getMenuAnimations(); },
             [](const std::any &value) { CFG_setMenuAnimations(std::any_cast<bool>(value)); },
             []() { CFG_setMenuAnimations(CFG_DEFAULT_SHOWMENUANIMATIONS);}});
-        appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Show menu transitions", "Enable or disable animated transitions", {false, true}, on_off,
-            []() -> std::any{ return CFG_getMenuTransitions(); },
-            [](const std::any &value) { CFG_setMenuTransitions(std::any_cast<bool>(value)); },
-            []() { CFG_setMenuTransitions(CFG_DEFAULT_SHOWMENUTRANSITIONS);}});
+        appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Menu transitions", "Style of animated transition when navigating menus", transition_mode_values, transition_mode_labels,
+            []() -> std::any { return CFG_getMenuTransitions(); },
+            [](const std::any &value) { CFG_setMenuTransitions(std::any_cast<int>(value)); },
+            []() { CFG_setMenuTransitions(CFG_DEFAULT_SHOWMENUTRANSITIONS); }});
         appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Game art corner radius", "Set the radius for the rounded corners of game art", 0, 24, "px",
             []() -> std::any{ return CFG_getThumbnailRadius(); },
             [](const std::any &value) { CFG_setThumbnailRadius(std::any_cast<int>(value)); },
@@ -451,9 +455,9 @@ int main(int argc, char *argv[])
         auto displayMenu = new MenuList(MenuItemType::Fixed, "Display", displayItems);
 
         std::vector<AbstractMenuItem*> systemItems = {
-            new MenuItem{ListItemType::Generic, "Volume", "Speaker volume", 
-            {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}, 
-            {"Muted", "5%","10%","15%","20%","25%","30%","35%","40%","45%","50%","55%","60%","65%","70%","75%","80%","85%","90%","95%","100%"}, 
+            new MenuItem{ListItemType::Generic, "Volume", "Speaker volume",
+            {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20},
+            {"Muted", "5%","10%","15%","20%","25%","30%","35%","40%","45%","50%","55%","60%","65%","70%","75%","80%","85%","90%","95%","100%"},
             []() -> std::any{ return GetVolume(); }, [](const std::any &value)
             { SetVolume(std::any_cast<int>(value)); },
             []() { SetVolume(SETTINGS_DEFAULT_VOLUME);}},
@@ -469,10 +473,10 @@ int main(int argc, char *argv[])
             { return CFG_getHaptics(); }, [](const std::any &value)
             { CFG_setHaptics(std::any_cast<bool>(value)); },
             []() { CFG_setHaptics(CFG_DEFAULT_HAPTICS);}},
-            new MenuItem{ListItemType::Generic, "Default view", "The initial view to show on boot", 
-            {(int)SCREEN_GAMELIST, (int)SCREEN_GAMESWITCHER, (int)SCREEN_QUICKMENU}, 
-            {"Content List","Game Switcher","Quick Menu"}, 
-            []() -> std::any { return CFG_getDefaultView(); }, 
+            new MenuItem{ListItemType::Generic, "Default view", "The initial view to show on boot",
+            {(int)SCREEN_GAMELIST, (int)SCREEN_GAMESWITCHER, (int)SCREEN_QUICKMENU},
+            {"Content List","Game Switcher","Quick Menu"},
+            []() -> std::any { return CFG_getDefaultView(); },
             [](const std::any &value){ CFG_setDefaultView(std::any_cast<int>(value)); },
             []() { CFG_setDefaultView(CFG_DEFAULT_VIEW);}},
             new MenuItem{ListItemType::Generic, "Show 24h time format", "Show clock in the 24hrs time format", {false, true}, on_off, []() -> std::any
@@ -493,19 +497,19 @@ int main(int argc, char *argv[])
             { return std::string(TIME_getCurrentTimezone()); }, [](const std::any &value)
             { TIME_setCurrentTimezone(std::any_cast<std::string>(value).c_str()); },
             []() { TIME_setCurrentTimezone("Asia/Shanghai");}}, // default from Stock
-            new MenuItem{ListItemType::Generic, "Save format", "The save format to use.\nMinUI: Game.gba.sav, Retroarch: Game.srm, Generic: Game.sav", 
-            {(int)SAVE_FORMAT_SAV, (int)SAVE_FORMAT_SRM, (int)SAVE_FORMAT_SRM_UNCOMPRESSED, (int)SAVE_FORMAT_GEN}, 
+            new MenuItem{ListItemType::Generic, "Save format", "The save format to use.\nMinUI: Game.gba.sav, Retroarch: Game.srm, Generic: Game.sav",
+            {(int)SAVE_FORMAT_SAV, (int)SAVE_FORMAT_SRM, (int)SAVE_FORMAT_SRM_UNCOMPRESSED, (int)SAVE_FORMAT_GEN},
             {"MinUI (default)", "Retroarch (compressed)", "Retroarch (uncompressed)", "Generic"}, []() -> std::any
             { return CFG_getSaveFormat(); }, [](const std::any &value)
             { CFG_setSaveFormat(std::any_cast<int>(value)); },
             []() { CFG_setSaveFormat(CFG_DEFAULT_SAVEFORMAT);}},
-            new MenuItem{ListItemType::Generic, "Save state format", "The save state format to use. MinUI: Game.st0, \nRetroarch-ish: Game.state.0, Retroarch: Game.state0", 
-            {(int)STATE_FORMAT_SAV, (int)STATE_FORMAT_SRM_EXTRADOT, (int)STATE_FORMAT_SRM_UNCOMRESSED_EXTRADOT, (int)STATE_FORMAT_SRM, (int)STATE_FORMAT_SRM_UNCOMRESSED}, 
+            new MenuItem{ListItemType::Generic, "Save state format", "The save state format to use. MinUI: Game.st0, \nRetroarch-ish: Game.state.0, Retroarch: Game.state0",
+            {(int)STATE_FORMAT_SAV, (int)STATE_FORMAT_SRM_EXTRADOT, (int)STATE_FORMAT_SRM_UNCOMRESSED_EXTRADOT, (int)STATE_FORMAT_SRM, (int)STATE_FORMAT_SRM_UNCOMRESSED},
             {"MinUI (default)", "Retroarch-ish (compressed)", "Retroarch-ish (uncompressed)", "Retroarch (compressed)", "Retroarch (uncompressed)"}, []() -> std::any
             { return CFG_getStateFormat(); }, [](const std::any &value)
             { CFG_setStateFormat(std::any_cast<int>(value)); },
             []() { CFG_setStateFormat(CFG_DEFAULT_STATEFORMAT);}},
-            new MenuItem{ListItemType::Generic, "Use extracted file name", "Use the extracted file name instead of the archive name.\nOnly applies to cores that do not handle archives natively", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Use extracted file name", "Use the extracted file name instead of the archive name.\nOnly applies to cores that do not handle archives natively", {false, true}, on_off,
             []() -> std::any{ return CFG_getUseExtractedFileName(); },
             [](const std::any &value){ CFG_setUseExtractedFileName(std::any_cast<bool>(value)); },
             []() { CFG_setUseExtractedFileName(CFG_DEFAULT_EXTRACTEDFILENAME);}}
@@ -514,7 +518,7 @@ int main(int argc, char *argv[])
         if(deviceInfo.getPlatform() == DeviceInfo::tg5040)
         {
             systemItems.push_back(
-                new MenuItem{ListItemType::Generic, "Safe poweroff", "Bypasses the stock shutdown procedure to avoid the \"limbo bug\".\nInstructs the PMIC directly to soft disconnect the battery.", {false, true}, on_off, 
+                new MenuItem{ListItemType::Generic, "Safe poweroff", "Bypasses the stock shutdown procedure to avoid the \"limbo bug\".\nInstructs the PMIC directly to soft disconnect the battery.", {false, true}, on_off,
                 []() -> std::any { return CFG_getPowerOffProtection(); },
                 [](const std::any &value) { CFG_setPowerOffProtection(std::any_cast<bool>(value)); },
                 []() { CFG_setPowerOffProtection(CFG_DEFAULT_POWEROFFPROTECTION); }}
@@ -524,8 +528,8 @@ int main(int argc, char *argv[])
         if(deviceInfo.hasActiveCooling())
         {
             systemItems.push_back(
-                new MenuItem{ListItemType::Generic, "Fan Speed", "Select the fan speed percentage (Quiet/Normal/Performance or 0-100%)", 
-                {-3,-2,-1,0,10,20,30,40,50,60,70,80,90,100}, {"Performance","Normal","Quiet","0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"}, 
+                new MenuItem{ListItemType::Generic, "Fan Speed", "Select the fan speed percentage (Quiet/Normal/Performance or 0-100%)",
+                {-3,-2,-1,0,10,20,30,40,50,60,70,80,90,100}, {"Performance","Normal","Quiet","0%","10%","20%","30%","40%","50%","60%","70%","80%","90%","100%"},
                 []() -> std::any { return GetFanSpeed(); },
                 [](const std::any &value){ SetFanSpeed(std::any_cast<int>(value)); },
                 []() { SetFanSpeed(SETTINGS_DEFAULT_FAN_SPEED); }}
@@ -537,32 +541,32 @@ int main(int argc, char *argv[])
 
         auto systemMenu = new MenuList(MenuItemType::Fixed, "System", systemItems);
 
-        std::vector<AbstractMenuItem*> muteItems = 
+        std::vector<AbstractMenuItem*> muteItems =
         {
-            new MenuItem{ListItemType::Generic, "Volume when toggled", "Speaker volume (0-20)", 
-            {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}, 
-            {"Unchanged", "Muted", "5%","10%","15%","20%","25%","30%","35%","40%","45%","50%","55%","60%","65%","70%","75%","80%","85%","90%","95%","100%"}, 
+            new MenuItem{ListItemType::Generic, "Volume when toggled", "Speaker volume (0-20)",
+            {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20},
+            {"Unchanged", "Muted", "5%","10%","15%","20%","25%","30%","35%","40%","45%","50%","55%","60%","65%","70%","75%","80%","85%","90%","95%","100%"},
             []() -> std::any { return GetMutedVolume(); },
             [](const std::any &value) { SetMutedVolume(std::any_cast<int>(value)); },
             []() { SetMutedVolume(0); }},
-            new MenuItem{ListItemType::Generic, "FN switch disables LED", "Switch will also disable LEDs", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "FN switch disables LED", "Switch will also disable LEDs", {false, true}, on_off,
             []() -> std::any { return CFG_getMuteLEDs(); },
             [](const std::any &value) { CFG_setMuteLEDs(std::any_cast<bool>(value)); },
             []() { CFG_setMuteLEDs(CFG_DEFAULT_MUTELEDS); }},
-            new MenuItem{ListItemType::Generic, "Brightness when toggled", "Display brightness (0 to 10)", 
-            {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, 0,1,2,3,4,5,6,7,8,9,10}, 
+            new MenuItem{ListItemType::Generic, "Brightness when toggled", "Display brightness (0 to 10)",
+            {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, 0,1,2,3,4,5,6,7,8,9,10},
             {"Unchanged","0","1","2","3","4","5","6","7","8","9","10"},
             []() -> std::any { return GetMutedBrightness(); }, [](const std::any &value)
             { SetMutedBrightness(std::any_cast<int>(value)); },
             []() { SetMutedBrightness(SETTINGS_DEFAULT_MUTE_NO_CHANGE);}},
         };
-        
+
         if(deviceInfo.hasMuteToggle())
         {
             if(deviceInfo.hasColorTemperature()) {
                 muteItems.push_back(
-                    new MenuItem{ListItemType::Generic, "Color temperature when toggled", "Color temperature (0 to 40)", 
-                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40}, 
+                    new MenuItem{ListItemType::Generic, "Color temperature when toggled", "Color temperature (0 to 40)",
+                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40},
                     {"Unchanged","0","1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40"},
                     []() -> std::any{ return GetMutedColortemp(); }, [](const std::any &value)
                     { SetMutedColortemp(std::any_cast<int>(value)); },
@@ -571,15 +575,15 @@ int main(int argc, char *argv[])
             }
             if(deviceInfo.hasContrastSaturation()) {
                 muteItems.insert(muteItems.end(), {
-                    new MenuItem{ListItemType::Generic, "Contrast when toggled", "Contrast enhancement (-4 to 5)", 
-                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, -4,-3,-2,-1,0,1,2,3,4,5}, 
-                    {"Unchanged","-4","-3","-2","-1","0","1","2","3","4","5"}, 
+                    new MenuItem{ListItemType::Generic, "Contrast when toggled", "Contrast enhancement (-4 to 5)",
+                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, -4,-3,-2,-1,0,1,2,3,4,5},
+                    {"Unchanged","-4","-3","-2","-1","0","1","2","3","4","5"},
                     []() -> std::any  { return GetMutedContrast(); }, [](const std::any &value)
                     { SetMutedContrast(std::any_cast<int>(value)); },
                     []() { SetMutedContrast(SETTINGS_DEFAULT_MUTE_NO_CHANGE);}},
-                    new MenuItem{ListItemType::Generic, "Saturation when toggled", "Saturation enhancement (-5 to 5)", 
-                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, -5,-4,-3,-2,-1,0,1,2,3,4,5}, 
-                    {"Unchanged","-5","-4","-3","-2","-1","0","1","2","3","4","5"}, 
+                    new MenuItem{ListItemType::Generic, "Saturation when toggled", "Saturation enhancement (-5 to 5)",
+                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, -5,-4,-3,-2,-1,0,1,2,3,4,5},
+                    {"Unchanged","-5","-4","-3","-2","-1","0","1","2","3","4","5"},
                     []() -> std::any{ return GetMutedSaturation(); }, [](const std::any &value)
                     { SetMutedSaturation(std::any_cast<int>(value)); },
                     []() { SetMutedSaturation(SETTINGS_DEFAULT_MUTE_NO_CHANGE);}}}
@@ -587,15 +591,15 @@ int main(int argc, char *argv[])
             }
             if(deviceInfo.hasExposure()) {
                 muteItems.push_back(
-                    new MenuItem{ListItemType::Generic, "Exposure when toggled", "Exposure enhancement (-4 to 5)", 
-                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, -4,-3,-2,-1,0,1,2,3,4,5}, 
-                    {"Unchanged","-4","-3","-2","-1","0","1","2","3","4","5"}, 
+                    new MenuItem{ListItemType::Generic, "Exposure when toggled", "Exposure enhancement (-4 to 5)",
+                    {(int)SETTINGS_DEFAULT_MUTE_NO_CHANGE, -4,-3,-2,-1,0,1,2,3,4,5},
+                    {"Unchanged","-4","-3","-2","-1","0","1","2","3","4","5"},
                     []() -> std::any  { return GetMutedExposure(); }, [](const std::any &value)
                     { SetMutedExposure(std::any_cast<int>(value)); },
                     []() { SetMutedExposure(SETTINGS_DEFAULT_MUTE_NO_CHANGE);}}
                 );
             }
-            
+
             muteItems.insert(muteItems.end(), {
                 new MenuItem{ListItemType::Generic, "Turbo fire A", "Enable turbo fire A", {0, 1}, on_off, []() -> std::any
                 { return GetMuteTurboA(); },
@@ -638,17 +642,17 @@ int main(int argc, char *argv[])
                 {
                     if(!GetMuteDisablesDpad() && !GetMuteEmulatesJoystick()) return 0;
                     if(GetMuteDisablesDpad() && GetMuteEmulatesJoystick()) return 1;
-                    return 2; 
+                    return 2;
                 },
                 [](const std::any &value)
-                { 
+                {
                     int v = std::any_cast<int>(value);
-                    SetMuteDisablesDpad((v == 1)); 
+                    SetMuteDisablesDpad((v == 1));
                     SetMuteEmulatesJoystick((v > 0));
                 },
                 []()
-                { 
-                    SetMuteDisablesDpad(0); 
+                {
+                    SetMuteDisablesDpad(0);
                     SetMuteEmulatesJoystick(0);
                 }});
         }
@@ -656,23 +660,23 @@ int main(int argc, char *argv[])
 
         auto notificationsMenu = new MenuList(MenuItemType::Fixed, "Notifications",
         {
-            new MenuItem{ListItemType::Generic, "Save states", "Show notification when saving game state", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Save states", "Show notification when saving game state", {false, true}, on_off,
             []() -> std::any { return CFG_getNotifyManualSave(); },
             [](const std::any &value) { CFG_setNotifyManualSave(std::any_cast<bool>(value)); },
             []() { CFG_setNotifyManualSave(CFG_DEFAULT_NOTIFY_MANUAL_SAVE);}},
-            new MenuItem{ListItemType::Generic, "Load states", "Show notification when loading game state", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Load states", "Show notification when loading game state", {false, true}, on_off,
             []() -> std::any { return CFG_getNotifyLoad(); },
             [](const std::any &value) { CFG_setNotifyLoad(std::any_cast<bool>(value)); },
             []() { CFG_setNotifyLoad(CFG_DEFAULT_NOTIFY_LOAD);}},
-            new MenuItem{ListItemType::Generic, "Screenshots", "Show notification when taking a screenshot", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Screenshots", "Show notification when taking a screenshot", {false, true}, on_off,
             []() -> std::any { return CFG_getNotifyScreenshot(); },
             [](const std::any &value) { CFG_setNotifyScreenshot(std::any_cast<bool>(value)); },
             []() { CFG_setNotifyScreenshot(CFG_DEFAULT_NOTIFY_SCREENSHOT);}},
-            new MenuItem{ListItemType::Generic, "Vol / Display Adjustments", "Show overlay for volume, brightness,\nand color temp adjustments", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Vol / Display Adjustments", "Show overlay for volume, brightness,\nand color temp adjustments", {false, true}, on_off,
             []() -> std::any { return CFG_getNotifyAdjustments(); },
             [](const std::any &value) { CFG_setNotifyAdjustments(std::any_cast<bool>(value)); },
             []() { CFG_setNotifyAdjustments(CFG_DEFAULT_NOTIFY_ADJUSTMENTS);}},
-            new MenuItem{ListItemType::Generic, "Duration", "How long notifications stay on screen", notify_duration_values, notify_duration_labels, 
+            new MenuItem{ListItemType::Generic, "Duration", "How long notifications stay on screen", notify_duration_values, notify_duration_labels,
             []() -> std::any { return CFG_getNotifyDuration(); },
             [](const std::any &value) { CFG_setNotifyDuration(std::any_cast<int>(value)); },
             []() { CFG_setNotifyDuration(CFG_DEFAULT_NOTIFY_DURATION);}},
@@ -684,7 +688,7 @@ int main(int argc, char *argv[])
             CFG_setRAUsername(item.getName().c_str());
             return Exit;
         });
-        
+
         auto raPasswordPrompt = new KeyboardPrompt("Enter Password", [](AbstractMenuItem &item) -> InputReactionHint {
             CFG_setRAPassword(item.getName().c_str());
             return Exit;
@@ -692,12 +696,12 @@ int main(int argc, char *argv[])
 
         auto retroAchievementsMenu = new MenuList(MenuItemType::Fixed, "RetroAchievements",
         {
-            new MenuItem{ListItemType::Generic, "Enable Achievements", "Enable RetroAchievements integration", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Enable Achievements", "Enable RetroAchievements integration", {false, true}, on_off,
             []() -> std::any { return CFG_getRAEnable(); },
             [](const std::any &value) { CFG_setRAEnable(std::any_cast<bool>(value)); },
             []() { CFG_setRAEnable(CFG_DEFAULT_RA_ENABLE);}},
             new TextInputMenuItem{"Username", "RetroAchievements username",
-            []() -> std::any { 
+            []() -> std::any {
                 std::string username = CFG_getRAUsername();
                 return username.empty() ? std::string("(not set)") : username;
             },
@@ -707,7 +711,7 @@ int main(int argc, char *argv[])
                 return NoOp;
             }, raUsernamePrompt},
             new TextInputMenuItem{"Password", "RetroAchievements password",
-            []() -> std::any { 
+            []() -> std::any {
                 std::string password = CFG_getRAPassword();
                 return password.empty() ? std::string("(not set)") : std::string("********");
             },
@@ -720,17 +724,17 @@ int main(int argc, char *argv[])
             [](AbstractMenuItem &item) -> InputReactionHint {
                 const char* username = CFG_getRAUsername();
                 const char* password = CFG_getRAPassword();
-                
+
                 if (!username || strlen(username) == 0 || !password || strlen(password) == 0) {
                     item.setDesc("Error: Username and password required");
                     return NoOp;
                 }
-                
+
                 item.setDesc("Authenticating...");
-                
+
                 RA_AuthResponse response;
                 RA_AuthResult result = RA_authenticateSync(username, password, &response);
-                
+
                 if (result == RA_AUTH_SUCCESS) {
                     CFG_setRAToken(response.token);
                     CFG_setRAAuthenticated(true);
@@ -752,23 +756,23 @@ int main(int argc, char *argv[])
                 return std::string("Not authenticated");
             }},
             // TODO: Hardcore mode hidden until feature is fully implemented and ready for the emulator approval process done by the RetroAchievements team
-            // new MenuItem{ListItemType::Generic, "Hardcore Mode", "Disable save states and cheats for achievements", {false, true}, on_off, 
+            // new MenuItem{ListItemType::Generic, "Hardcore Mode", "Disable save states and cheats for achievements", {false, true}, on_off,
             // []() -> std::any { return CFG_getRAHardcoreMode(); },
             // [](const std::any &value) { CFG_setRAHardcoreMode(std::any_cast<bool>(value)); },
             // []() { CFG_setRAHardcoreMode(CFG_DEFAULT_RA_HARDCOREMODE);}},
-            new MenuItem{ListItemType::Generic, "Show Notifications", "Show achievement unlock notifications", {false, true}, on_off, 
+            new MenuItem{ListItemType::Generic, "Show Notifications", "Show achievement unlock notifications", {false, true}, on_off,
             []() -> std::any { return CFG_getRAShowNotifications(); },
             [](const std::any &value) { CFG_setRAShowNotifications(std::any_cast<bool>(value)); },
             []() { CFG_setRAShowNotifications(CFG_DEFAULT_RA_SHOW_NOTIFICATIONS);}},
-            new MenuItem{ListItemType::Generic, "Notification Duration", "How long achievement notifications stay on screen", notify_duration_values, notify_duration_labels, 
+            new MenuItem{ListItemType::Generic, "Notification Duration", "How long achievement notifications stay on screen", notify_duration_values, notify_duration_labels,
             []() -> std::any { return CFG_getRANotificationDuration(); },
             [](const std::any &value) { CFG_setRANotificationDuration(std::any_cast<int>(value)); },
             []() { CFG_setRANotificationDuration(CFG_DEFAULT_RA_NOTIFICATION_DURATION);}},
-            new MenuItem{ListItemType::Generic, "Progress Duration", "Duration for progress updates (top-left). Off to disable.", progress_duration_values, progress_duration_labels, 
+            new MenuItem{ListItemType::Generic, "Progress Duration", "Duration for progress updates (top-left). Off to disable.", progress_duration_values, progress_duration_labels,
             []() -> std::any { return CFG_getRAProgressNotificationDuration(); },
             [](const std::any &value) { CFG_setRAProgressNotificationDuration(std::any_cast<int>(value)); },
             []() { CFG_setRAProgressNotificationDuration(CFG_DEFAULT_RA_PROGRESS_NOTIFICATION_DURATION);}},
-            new MenuItem{ListItemType::Generic, "Achievement Sort Order", "How achievements are sorted in the in-game menu", ra_sort_values, ra_sort_labels, 
+            new MenuItem{ListItemType::Generic, "Achievement Sort Order", "How achievements are sorted in the in-game menu", ra_sort_values, ra_sort_labels,
             []() -> std::any { return CFG_getRAAchievementSortOrder(); },
             [](const std::any &value) { CFG_setRAAchievementSortOrder(std::any_cast<int>(value)); },
             []() { CFG_setRAAchievementSortOrder(CFG_DEFAULT_RA_ACHIEVEMENT_SORT_ORDER);}},
@@ -780,8 +784,8 @@ int main(int argc, char *argv[])
             new MenuItem{ListItemType::Generic, "Notifications", "Save state notifications", {}, {}, nullptr, nullptr, DeferToSubmenu, notificationsMenu},
             new MenuItem{ListItemType::Generic, "RetroAchievements", "Achievement tracking settings", {}, {}, nullptr, nullptr, DeferToSubmenu, retroAchievementsMenu},
         });
-      
-        // We need to alert the user about potential issues if the 
+
+        // We need to alert the user about potential issues if the
         // stock OS was modified in way that are known to cause issues
         std::string bbver = extractBusyBoxVersion(execCommand("cat --help"));
         if (bbver.empty())
@@ -791,29 +795,29 @@ int main(int argc, char *argv[])
                 "Stock OS changes detected.\n"
                 "This may cause instability or issues.\n"
                 "If you experience problems, please consider\n"
-                "reverting to clean stock firmware.", 
+                "reverting to clean stock firmware.",
                 OverlayDismissMode::DismissOnA);
 
         auto aboutMenu = new MenuList(MenuItemType::Fixed, "About",
         {
-            new StaticMenuItem{ListItemType::Generic, "NextUI version", "", 
-            []() -> std::any { 
+            new StaticMenuItem{ListItemType::Generic, "NextUI version", "",
+            []() -> std::any {
                 std::ifstream t(ROOT_SYSTEM_PATH "/version.txt");
                 std::stringstream buffer;
                 buffer << t.rdbuf();
                 return buffer.str();
             }},
-            new StaticMenuItem{ListItemType::Generic, "Platform", "", 
-            []() -> std::any { 
+            new StaticMenuItem{ListItemType::Generic, "Platform", "",
+            []() -> std::any {
                 return std::string(PLAT_getModel()); }
             },
-            new StaticMenuItem{ListItemType::Generic, "Stock OS version", "", 
-            []() -> std::any { 
+            new StaticMenuItem{ListItemType::Generic, "Stock OS version", "",
+            []() -> std::any {
                 char osver[128];
                 PLAT_getOsVersionInfo(osver, 128);
                 return std::string(osver); }
             },
-            new StaticMenuItem{ListItemType::Generic, "Busybox version", "", 
+            new StaticMenuItem{ListItemType::Generic, "Busybox version", "",
             [&]() -> std::any { return bbver; }
             },
         });
@@ -823,16 +827,16 @@ int main(int argc, char *argv[])
             new MenuItem{ListItemType::Generic, "Display", "", {}, {}, nullptr, nullptr, DeferToSubmenu, displayMenu},
             new MenuItem{ListItemType::Generic, "System", "", {}, {}, nullptr, nullptr, DeferToSubmenu, systemMenu},
         };
-        
+
         if(deviceInfo.hasMuteToggle())
-            mainItems.push_back(new MenuItem{ListItemType::Generic, "FN switch", "FN switch settings", {}, {}, nullptr, nullptr, DeferToSubmenu, 
+            mainItems.push_back(new MenuItem{ListItemType::Generic, "FN switch", "FN switch settings", {}, {}, nullptr, nullptr, DeferToSubmenu,
                 new MenuList(MenuItemType::Fixed, "FN Switch", muteItems)});
-      
+
         mainItems.push_back(new MenuItem{ListItemType::Generic, "In-Game", "In-game settings for MinArch", {}, {}, nullptr, nullptr, DeferToSubmenu, minarchMenu});
-            
+
         if(deviceInfo.hasWifi())
             mainItems.push_back(new MenuItem{ListItemType::Generic, "Network", "", {}, {}, nullptr, nullptr, DeferToSubmenu, new Wifi::Menu(appQuit, ctx.dirty)});
-        
+
         if(deviceInfo.hasBluetooth())
             mainItems.push_back(new MenuItem{ListItemType::Generic, "Bluetooth", "", {}, {}, nullptr, nullptr, DeferToSubmenu, new Bluetooth::Menu(appQuit, ctx.dirty)});
 
@@ -843,7 +847,7 @@ int main(int argc, char *argv[])
         SDL_Surface* bgbmp = IMG_Load(SDCARD_PATH "/bg.png");
         SDL_Surface* convertedbg = SDL_ConvertSurfaceFormat(bgbmp, SDL_PIXELFORMAT_RGB565, 0);
         if (convertedbg) {
-            SDL_FreeSurface(bgbmp); 
+            SDL_FreeSurface(bgbmp);
             SDL_Surface* scaled = SDL_CreateRGBSurfaceWithFormat(0, ctx.screen->w, ctx.screen->h, 32, SDL_PIXELFORMAT_RGB565);
             GFX_blitScaleToFill(convertedbg, scaled);
             bgbmp = scaled;
@@ -871,7 +875,7 @@ int main(int argc, char *argv[])
             PWR_update(&ctx.dirty, &ctx.show_setting, nullptr, nullptr);
 
             int is_online = PWR_isOnline();
-            if (was_online!=is_online) 
+            if (was_online!=is_online)
                 ctx.dirty = 1;
             was_online = is_online;
 


### PR DESCRIPTION
## What

- Updates the animation to a common Push Pop style animation (seen commonly on mobile devices)
- Updates the Menu transitions setting to have "Off", "Snappy", and "Comfy", with snappy being 150ms and comfy being 250ms. Both animations use an intensity of 3 with an easing of Ease out. 

## Why

The existing animation doesn't blend well, especially when backing out, and can look confusing with the opacity transition. The new transition should flow better. 

## How

1. Updates transition of the SDL surfaces
2. Fixes pill blinking on incoming screen
3. Adds animation defines for easing
4. Updates settings to handle the new options. Handles existing settings by bool 0 = Option off, staying off, and bool 1 = Option Snappy (the default)