### PR TITLE
Feature/podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ audiomon.elf
 
 workspace/hash.txt
 workspace/readmes
+workspace/.container_runtime

--- a/makefile.toolchain
+++ b/makefile.toolchain
@@ -13,8 +13,13 @@ GIT_IF_NECESSARY=toolchains/$(PLATFORM)-toolchain
 INIT_IF_NECESSARY=toolchains/$(PLATFORM)-toolchain/.build
 IMAGE_NAME=ghcr.io/loveretro/$(PLATFORM)-toolchain:latest
 
+CONTAINER_RUNTIME ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
+ifeq (,$(CONTAINER_RUNTIME))
+$(error Neither docker nor podman found in PATH)
+endif
+
 all: $(INIT_IF_NECESSARY)
-	docker run -it --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash
+	$(CONTAINER_RUNTIME) run -it --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash
 
 $(INIT_IF_NECESSARY): $(GIT_IF_NECESSARY)
 	cd toolchains/$(PLATFORM)-toolchain && make .build
@@ -22,19 +27,19 @@ $(INIT_IF_NECESSARY): $(GIT_IF_NECESSARY)
 $(GIT_IF_NECESSARY):
 	mkdir -p toolchains
 	git clone https://github.com/LoveRetro/$(PLATFORM)-toolchain/ toolchains/$(PLATFORM)-toolchain
-	docker pull $(IMAGE_NAME) && touch toolchains/$(PLATFORM)-toolchain/.build
+	$(CONTAINER_RUNTIME) pull $(IMAGE_NAME) && touch toolchains/$(PLATFORM)-toolchain/.build
 
 clean:
 	cd toolchains/$(PLATFORM)-toolchain && make clean
 
 build: $(INIT_IF_NECESSARY)
-	docker run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make'
+	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make'
 
 build-cores: $(INIT_IF_NECESSARY)
-	docker run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make cores'
+	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make cores'
 
 build-core: $(INIT_IF_NECESSARY)
 ifndef CORE
 	$(error CORE is not set)
 endif
-	docker run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) -e CORE=$(CORE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make core'
+	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) -e CORE=$(CORE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make core'

--- a/makefile.toolchain
+++ b/makefile.toolchain
@@ -1,6 +1,6 @@
 # there is no reason to use this makefile manually
 
-.PHONY: build clean
+.PHONY: build clean _runtime_check
 
 ifeq (,$(PLATFORM))
 $(error please specify PLATFORM, eg. make PLATFORM=trimui)
@@ -18,6 +18,10 @@ ifeq (,$(CONTAINER_RUNTIME))
 $(error Neither docker nor podman found in PATH)
 endif
 
+RUNTIME_MARKER := $(HOST_WORKSPACE)/.container_runtime
+LAST_RUNTIME := $(shell cat $(RUNTIME_MARKER) 2>/dev/null)
+CURRENT_RUNTIME := $(notdir $(CONTAINER_RUNTIME))
+
 all: $(INIT_IF_NECESSARY)
 	$(CONTAINER_RUNTIME) run -it --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash
 
@@ -32,14 +36,31 @@ $(GIT_IF_NECESSARY):
 clean:
 	cd toolchains/$(PLATFORM)-toolchain && make clean
 
-build: $(INIT_IF_NECESSARY)
+_runtime_check:
+	@if [ -n "$(LAST_RUNTIME)" ] && [ "$(LAST_RUNTIME)" != "$(CURRENT_RUNTIME)" ]; then \
+		echo "Container runtime changed ($(LAST_RUNTIME) -> $(CURRENT_RUNTIME)), cleaning workspace build artifacts..."; \
+		PREV=$$(command -v $(LAST_RUNTIME) 2>/dev/null); \
+		if [ -n "$$PREV" ]; then \
+			$$PREV run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c \
+				'find $(GUEST_WORKSPACE) -depth -user root -delete 2>/dev/null; true'; \
+		else \
+			echo "Error: previous runtime $(LAST_RUNTIME) not available to clean root-owned artifacts."; \
+			echo "Run: sudo rm -rf $(HOST_WORKSPACE)/*/build $(HOST_WORKSPACE)/$(PLATFORM)/other"; \
+			exit 1; \
+		fi; \
+	fi
+
+build: $(INIT_IF_NECESSARY) _runtime_check
 	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make'
+	@echo "$(CURRENT_RUNTIME)" > $(RUNTIME_MARKER)
 
-build-cores: $(INIT_IF_NECESSARY)
+build-cores: $(INIT_IF_NECESSARY) _runtime_check
 	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make cores'
+	@echo "$(CURRENT_RUNTIME)" > $(RUNTIME_MARKER)
 
-build-core: $(INIT_IF_NECESSARY)
+build-core: $(INIT_IF_NECESSARY) _runtime_check
 ifndef CORE
 	$(error CORE is not set)
 endif
 	$(CONTAINER_RUNTIME) run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) -e COMPILE_CORES=$(COMPILE_CORES) -e CORE=$(CORE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make core'
+	@echo "$(CURRENT_RUNTIME)" > $(RUNTIME_MARKER)

--- a/workspace/tg5040/btmanager/Makefile
+++ b/workspace/tg5040/btmanager/Makefile
@@ -54,3 +54,6 @@ bluez:
 	cd build && python3 -m zipfile -c nextui.upgrade_bluez.pakz .update_bluez/ post_install.sh
 
 all: bluez
+
+clean:
+	rm -rf ./build


### PR DESCRIPTION
The build system previously had Docker hardcoded as the only container runtime. This PR adds support for Podman as a drop-in alternative, which is useful on systems where Docker is not available or not preferred (e.g. rootless Linux setups where Podman is the default).

makefile.toolchain:
  - Detects available container runtime at build time: Docker is preferred when both are installed, Podman is used as a fallback when Docker is absent
  - Allows explicitly overriding the runtime via CONTAINER_RUNTIME=podman on the make command line
  - Tracks the last-used runtime in workspace/.container_runtime and automatically cleans workspace artifacts when switching
  between runtimes
  
Automatic cleanup is needed as Docker containers run as root, so compiled objects and cloned repos (e.g. other/NextCommander) end up root-owned on the host. Rootless Podman cannot write into those directories. When a runtime switch is detected, the cleanup runs inside the previous container using find -depth -user root -delete, which removes only what that runtime created while leaving host-owned source files untouched. If the previous runtime is no longer installed, an actionable manual cleanup command is printed and the build aborts rather than producing a half-broken state.

workspace/tg5040/btmanager/Makefile:
  - Added missing clean target (pre-existing gap, caught during testing when the cleanup path exercised it for the first time)
  
  Examples:
  ```
  # uses docker if available, podman otherwise
  make PLATFORM=tg5040 build
  ```

```
# explicitly use podman
make PLATFORM=tg5040 build CONTAINER_RUNTIME=podman
```

```
# switching runtimes is handled automatically - no manual clean needed
make PLATFORM=tg5040 build                           # builds with docker, records runtime
make PLATFORM=tg5040 build CONTAINER_RUNTIME=podman  # detects switch, cleans, rebuilds
```

Build tests:
```
Docker (29.4.1) — successful build:
make build -f makefile.toolchain PLATFORM=tg5040 COMPILE_CORES=
docker run --rm -v .../workspace:/root/workspace ...
...
echo "skipping core build"
skipping core build
# ----------------------------------------------------
Artifacts owned by root on the host (expected Docker behaviour).

Podman (5.8.2) — successful build after automatic cleanup:
make build -f makefile.toolchain PLATFORM=tg5040 COMPILE_CORES=
Container runtime changed (docker -> podman), cleaning workspace build artifacts...
podman run --rm -v .../workspace:/root/workspace ...
...
echo "skipping core build"
skipping core build
# ----------------------------------------------------
Artifacts owned by the host user after the build, confirming rootless Podman mapped ownership correctly:
-rwxr-xr-x 1 carroarmato0 carroarmato0 557576 Apr 30 09:04 workspace/all/minarch/build/tg5040/minarch.elf
-rwxr-xr-x 1 carroarmato0 carroarmato0 149728 Apr 30 09:04 workspace/all/nextui/build/tg5040/nextui.elf
```