### PR TITLE
fix: picodrive crash when enabling cheats in SMS mode

### DIFF
--- a/workspace/all/cores/patches/picodrive/001-skip-ram-patching-on-sms.patch
+++ b/workspace/all/cores/patches/picodrive/001-skip-ram-patching-on-sms.patch
@@ -1,0 +1,20 @@
+--- a/platform/libretro/libretro.c
++++ b/platform/libretro/libretro.c
+@@ -856,7 +856,7 @@
+ 		if (addr < Pico.romsize) {
+ 			if (PicoPatches[i].active)
+ 				*(unsigned short *)(Pico.rom + addr) = PicoPatches[i].data_old;
+-		} else {
++		} else if (!(PicoIn.AHW & PAHW_SMS)) {
+ 			if (PicoPatches[i].active)
+ 				m68k_write16(PicoPatches[i].addr,PicoPatches[i].data_old);
+ 		}
+@@ -907,7 +907,7 @@
+ 		PicoPatches[PicoPatchCount].comp = pt.comp;
+ 		if (PicoPatches[PicoPatchCount].addr < Pico.romsize)
+ 			PicoPatches[PicoPatchCount].data_old = *(uint16_t *)(Pico.rom + PicoPatches[PicoPatchCount].addr);
+-		else
++		else if (!(PicoIn.AHW & PAHW_SMS))
+ 			PicoPatches[PicoPatchCount].data_old = (uint16_t) m68k_read16(PicoPatches[PicoPatchCount].addr);
+ 		PicoPatchCount++;
+ 


### PR DESCRIPTION
## Summary

Using Action Replay cheats for Sega Master System causes a SIGSEGV crash in picodrive core.

The issue is that Action Replay hardware patches RAM region, but picodrive only supports RAM patching (customary for Game Genie hardware).

# Changes

- add `!(PicoIn.AHW & PAHW_SMS)` guard so the M68K accessors are only reached when actually emulating a Genesis/Mega Drive
  - RAM patching for SMS is silently skipped, which is correct behavior — SMS uses a Z80, not an M68K, so those functions were never the right tool for SMS RAM patching.
  - The vast majority of SMS cheats in the libretro database are Action Replay format targeting RAM addresses, so all of them previously caused a crash.

The same fix is also posted to upstream: https://github.com/irixxxx/picodrive/pull/218

## Test plan

- Load "Wonder Boy in Monster Land" game
- Load Action Replay [cheat](https://github.com/libretro/libretro-database/blob/master/cht/Sega%20-%20Master%20System%20-%20Mark%20III/Wonder%20Boy%20in%20Monster%20Land%20(USA%2C%20Europe)%20(Action%20Replay).cht) from libretro database
- Select a cheat from menu