### PR TITLE
fix: Game Tracker truncating names containing dots

### DIFF
--- a/workspace/all/common/utils.c
+++ b/workspace/all/common/utils.c
@@ -258,8 +258,7 @@ void folderPath(const char *path, char *result) {
 }
 void cleanName(char *name_out, const char *file_name)
 {
-    char *name_without_ext = removeExtension(file_name);
-    char *no_underscores = replaceString2(name_without_ext, "_", " ");
+    char *no_underscores = replaceString2(file_name, "_", " ");
     char *dot_ptr = strstr(no_underscores, ".");
     if (dot_ptr != NULL) {
         char *s = no_underscores;
@@ -277,7 +276,6 @@ void cleanName(char *name_out, const char *file_name)
         dot_ptr = no_underscores;
     }
     removeParentheses(name_out, dot_ptr);
-    free(name_without_ext);
     free(no_underscores);
 }
 bool pathRelativeTo(char *path_out, const char *dir_from, const char *file_to)


### PR DESCRIPTION
## Summary
- `cleanName()` called `removeExtension()` on game names already stored in the DB without file extensions
- This caused names with dots like "Gun.Smoke" to be truncated to "Gun" in Game Tracker
- Fix: remove the redundant `removeExtension()` call from `cleanName()`

This is an extremely rare case with ROMs released by No-Intro — Gun.Smoke (USA).nes may literally be the only one — but could come into play with homebrew games.

## Test plan
- [ ] Verify "Gun.Smoke" displays correctly in Game Tracker
- [ ] Verify games without dots still display correctly