### PR TITLE
fix: slowdowns on Auto cpu speed

### DIFF
--- a/skeleton/SYSTEM/tg5040/bin/governor.sh
+++ b/skeleton/SYSTEM/tg5040/bin/governor.sh
@@ -39,12 +39,12 @@ set_policy() {
 
 case "$MODE" in
 	auto)
-		# ondemand governor, min freq to one step below max (408-1800 MHz on TG5040)
-		set_policy /sys/devices/system/cpu/cpufreq/policy0 "ondemand" "second_max"
+		# schedutil governor, min freq to one step below max (408-1800 MHz on TG5040)
+		set_policy /sys/devices/system/cpu/cpufreq/policy0 "schedutil" "second_max"
 		;;
 	performance)
-		# schedutil governor, min freq to max freq (408-2000 MHz on TG5040)
-		set_policy /sys/devices/system/cpu/cpufreq/policy0 "schedutil" "max"
+		# performance governor, max freq (2000 MHz on TG5040)
+		set_policy /sys/devices/system/cpu/cpufreq/policy0 "performance" "max"
 		;;
 	powersave)
 		# conservative governor, min freq to midpoint max (408-1200 MHz on TG5040)

--- a/skeleton/SYSTEM/tg5050/bin/governor.sh
+++ b/skeleton/SYSTEM/tg5050/bin/governor.sh
@@ -43,16 +43,16 @@ apply_mode() {
 	
 	case "$mode" in
 		auto)
-			# ondemand governor, min freq to one step below max
+			# schedutil governor, min freq to one step below max
 			# policy0 - little Cores (408-1320 MHz on TG5050)
 			# policy4 - BIG Cores (408-2088 MHz on TG5050)
-			set_policy "$policy" "ondemand" "second_max"
+			set_policy "$policy" "schedutil" "second_max"
 			;;
 		performance)
-			# schedutil governor, min freq to max freq
-			# policy0 - little Cores (408-1416 MHz on TG5050)
-			# policy4 - BIG Cores (408-2160 MHz on TG5050)
-			set_policy "$policy" "schedutil" "max"
+			# performance governor, max freq
+			# policy0 - little Cores (1416 MHz on TG5050)
+			# policy4 - BIG Cores (2160 MHz on TG5050)
+			set_policy "$policy" "performance" "max"
 			;;
 		powersave)
 			# conservative governor, min freq to midpoint max


### PR DESCRIPTION
The 'ondemand' governor that was being used for Auto cpu speed seems to behave randomly/erratically. After a lot of testing I have changed it to schedutil. This performs much better on a wide variety of games and emulator cores, often outperforming even the Powersave profile (which uses the 'conservative' governor), resulting in lower cpu frequency and similar core temperatures while maintaining solid performance.

That leaves the Performance cpu speed option as being a copy of Auto but just enabling the highest (overclocked) CPU speed. Instead of that, I thought it's worthwhile to have a locked-to-max CPU speed option free from any autoscaling for the truly demanding games (MSDOS games, OMF2097 being one example).

Finally, the Powersave profile is now obsolete but it's left in for now. Auto now performs better than Powersave, providing lower clock speeds than Powersave. A future change should probably remove Powersave profile entirely.

Closes #726 