### PR TITLE
feat: support custom fonts in system settings

### DIFF
--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -1095,7 +1095,14 @@ void CFG_get(const char *key, char *value)
 {
     if (strcmp(key, "font") == 0)
     {
-        sprintf(value, "%s", CFG_getFontFile());
+        // backward compat: return integer for built-in fonts
+        const char *f = CFG_getFontFile();
+        if (strcmp(f, "font1.ttf") == 0)
+            sprintf(value, "1");
+        else if (strcmp(f, "font2.ttf") == 0)
+            sprintf(value, "0");
+        else
+            sprintf(value, "%s", f);
     }
     else if (strcmp(key, "color1") == 0)
     {
@@ -1280,7 +1287,14 @@ void CFG_sync(void)
         return;
     }
 
-    fprintf(file, "font=%s\n", settings.fontFile);
+    // backward compat: write integer for built-in fonts so existing paks
+    // that parse "font=" as an int keep working
+    if (strcmp(settings.fontFile, "font1.ttf") == 0)
+        fprintf(file, "font=1\n");
+    else if (strcmp(settings.fontFile, "font2.ttf") == 0)
+        fprintf(file, "font=0\n");
+    else
+        fprintf(file, "font=%s\n", settings.fontFile);
     fprintf(file, "color1=0x%06X\n", settings.color1_255);
     fprintf(file, "color2=0x%06X\n", settings.color2_255);
     fprintf(file, "color3=0x%06X\n", settings.color3_255);
@@ -1342,7 +1356,13 @@ void CFG_sync(void)
 void CFG_print(void)
 {
     printf("{\n");
-    printf("\t\"font\": \"%s\",\n", settings.fontFile);
+    // backward compat: output integer for built-in fonts
+    if (strcmp(settings.fontFile, "font1.ttf") == 0)
+        printf("\t\"font\": \"1\",\n");
+    else if (strcmp(settings.fontFile, "font2.ttf") == 0)
+        printf("\t\"font\": \"0\",\n");
+    else
+        printf("\t\"font\": \"%s\",\n", settings.fontFile);
     printf("\t\"color1\": \"0x%06X\",\n", settings.color1_255);
     printf("\t\"color2\": \"0x%06X\",\n", settings.color2_255);
     printf("\t\"color3\": \"0x%06X\",\n", settings.color3_255);

--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -446,14 +446,9 @@ void CFG_setFontFile(const char* filename)
         settings.fontFile[sizeof(settings.fontFile) - 1] = '\0';
     }
 
-    // resolve full path: built-ins in RES_PATH, custom fonts in FONTS_PATH
+    // resolve full path: all fonts live in RES_PATH
     char fontPath[512];
-    if (strcmp(settings.fontFile, "font1.ttf") == 0 ||
-        strcmp(settings.fontFile, "font2.ttf") == 0) {
-        snprintf(fontPath, sizeof(fontPath), "%s/%s", RES_PATH, settings.fontFile);
-    } else {
-        snprintf(fontPath, sizeof(fontPath), "%s/%s", FONTS_PATH, settings.fontFile);
-    }
+    snprintf(fontPath, sizeof(fontPath), "%s/%s", RES_PATH, settings.fontFile);
 
     // fall back to default if file doesn't exist
     if (access(fontPath, F_OK) != 0) {
@@ -1095,14 +1090,12 @@ void CFG_get(const char *key, char *value)
 {
     if (strcmp(key, "font") == 0)
     {
-        // backward compat: return integer for built-in fonts
+        // backward compat: always return integer (default 1 for custom fonts)
         const char *f = CFG_getFontFile();
-        if (strcmp(f, "font1.ttf") == 0)
-            sprintf(value, "1");
-        else if (strcmp(f, "font2.ttf") == 0)
+        if (strcmp(f, "font2.ttf") == 0)
             sprintf(value, "0");
         else
-            sprintf(value, "%s", f);
+            sprintf(value, "1");
     }
     else if (strcmp(key, "color1") == 0)
     {
@@ -1256,11 +1249,7 @@ void CFG_get(const char *key, char *value)
     // meta, not a real setting
     else if (strcmp(key, "fontpath") == 0)
     {
-        const char *f = CFG_getFontFile();
-        if (strcmp(f, "font1.ttf") == 0 || strcmp(f, "font2.ttf") == 0)
-            sprintf(value, "\"%s/%s\"", RES_PATH, f);
-        else
-            sprintf(value, "\"%s/%s\"", FONTS_PATH, f);
+        sprintf(value, "\"%s/%s\"", RES_PATH, CFG_getFontFile());
     }
 
     else {
@@ -1356,13 +1345,11 @@ void CFG_sync(void)
 void CFG_print(void)
 {
     printf("{\n");
-    // backward compat: output integer for built-in fonts
-    if (strcmp(settings.fontFile, "font1.ttf") == 0)
-        printf("\t\"font\": \"1\",\n");
-    else if (strcmp(settings.fontFile, "font2.ttf") == 0)
-        printf("\t\"font\": \"0\",\n");
+    // backward compat: always output integer (default 1 for custom fonts)
+    if (strcmp(settings.fontFile, "font2.ttf") == 0)
+        printf("\t\"font\": 0,\n");
     else
-        printf("\t\"font\": \"%s\",\n", settings.fontFile);
+        printf("\t\"font\": 1,\n");
     printf("\t\"color1\": \"0x%06X\",\n", settings.color1_255);
     printf("\t\"color2\": \"0x%06X\",\n", settings.color2_255);
     printf("\t\"color3\": \"0x%06X\",\n", settings.color3_255);
@@ -1403,11 +1390,7 @@ void CFG_print(void)
     printf("\t\"currentTimezone\": %i,\n", settings.currentTimezone);
 
     // meta, not a real setting
-    const char *fp = CFG_getFontFile();
-    if (strcmp(fp, "font1.ttf") == 0 || strcmp(fp, "font2.ttf") == 0)
-        printf("\t\"fontpath\": \"%s/%s\"\n", RES_PATH, fp);
-    else
-        printf("\t\"fontpath\": \"%s/%s\"\n", FONTS_PATH, fp);
+    printf("\t\"fontpath\": \"%s/%s\"\n", RES_PATH, CFG_getFontFile());
 
     printf("}\n");
 }

--- a/workspace/all/common/config.c
+++ b/workspace/all/common/config.c
@@ -30,7 +30,7 @@ void CFG_defaults(NextUISettings *cfg)
         return;
 
     NextUISettings defaults = {
-        .font = CFG_DEFAULT_FONT_ID,
+        .fontFile = CFG_DEFAULT_FONT_FILE,
         .color1_255 = CFG_DEFAULT_COLOR1,
         .color2_255 = CFG_DEFAULT_COLOR2,
         .color3_255 = CFG_DEFAULT_COLOR3,
@@ -119,9 +119,17 @@ void CFG_init(FontLoad_callback_t cb, ColorSet_callback_t ccb)
         {
             int temp_value;
             uint32_t temp_color;
-            if (sscanf(line, "font=%i", &temp_value) == 1)
+            if (strncmp(line, "font=", 5) == 0)
             {
-                CFG_setFontId(temp_value);
+                char *value = line + 5;
+                value[strcspn(value, "\n")] = 0;
+                // backward compat: "0" -> font2.ttf, "1" -> font1.ttf
+                if (strcmp(value, "0") == 0)
+                    CFG_setFontFile("font2.ttf");
+                else if (strcmp(value, "1") == 0)
+                    CFG_setFontFile("font1.ttf");
+                else
+                    CFG_setFontFile(value);
                 fontLoaded = true;
                 continue;
             }
@@ -420,25 +428,41 @@ void CFG_init(FontLoad_callback_t cb, ColorSet_callback_t ccb)
     CFG_setColor(7, CFG_getColor(COLOR_BACKGROUND));
     // avoid reloading the font if not neccessary
     if (!fontLoaded)
-        CFG_setFontId(CFG_getFontId());
+        CFG_setFontFile(CFG_getFontFile());
 }
 
-int CFG_getFontId(void)
+const char* CFG_getFontFile(void)
 {
-    return settings.font;
+    return settings.fontFile;
 }
 
-void CFG_setFontId(int id)
+void CFG_setFontFile(const char* filename)
 {
-    settings.font = clamp(id, 0, 2);
+    if (!filename || !filename[0]) {
+        strncpy(settings.fontFile, CFG_DEFAULT_FONT_FILE, sizeof(settings.fontFile) - 1);
+        settings.fontFile[sizeof(settings.fontFile) - 1] = '\0';
+    } else {
+        strncpy(settings.fontFile, filename, sizeof(settings.fontFile) - 1);
+        settings.fontFile[sizeof(settings.fontFile) - 1] = '\0';
+    }
 
-    char *fontPath;
-    if (settings.font == 1)
-        fontPath = RES_PATH "/font1.ttf";
-    else
-        fontPath = RES_PATH "/font2.ttf";
+    // resolve full path: built-ins in RES_PATH, custom fonts in FONTS_PATH
+    char fontPath[512];
+    if (strcmp(settings.fontFile, "font1.ttf") == 0 ||
+        strcmp(settings.fontFile, "font2.ttf") == 0) {
+        snprintf(fontPath, sizeof(fontPath), "%s/%s", RES_PATH, settings.fontFile);
+    } else {
+        snprintf(fontPath, sizeof(fontPath), "%s/%s", FONTS_PATH, settings.fontFile);
+    }
 
-    if(settings.onFontChange)
+    // fall back to default if file doesn't exist
+    if (access(fontPath, F_OK) != 0) {
+        strncpy(settings.fontFile, CFG_DEFAULT_FONT_FILE, sizeof(settings.fontFile) - 1);
+        settings.fontFile[sizeof(settings.fontFile) - 1] = '\0';
+        snprintf(fontPath, sizeof(fontPath), "%s/%s", RES_PATH, settings.fontFile);
+    }
+
+    if (settings.onFontChange)
         settings.onFontChange(fontPath);
 }
 
@@ -1071,7 +1095,7 @@ void CFG_get(const char *key, char *value)
 {
     if (strcmp(key, "font") == 0)
     {
-        sprintf(value, "%i", CFG_getFontId());
+        sprintf(value, "%s", CFG_getFontFile());
     }
     else if (strcmp(key, "color1") == 0)
     {
@@ -1225,10 +1249,11 @@ void CFG_get(const char *key, char *value)
     // meta, not a real setting
     else if (strcmp(key, "fontpath") == 0)
     {
-        if (CFG_getFontId() == 1)
-            sprintf(value, "\"%s\"", RES_PATH "/font1.ttf");
+        const char *f = CFG_getFontFile();
+        if (strcmp(f, "font1.ttf") == 0 || strcmp(f, "font2.ttf") == 0)
+            sprintf(value, "\"%s/%s\"", RES_PATH, f);
         else
-            sprintf(value, "\"%s\"", RES_PATH "/font2.ttf");
+            sprintf(value, "\"%s/%s\"", FONTS_PATH, f);
     }
 
     else {
@@ -1255,7 +1280,7 @@ void CFG_sync(void)
         return;
     }
 
-    fprintf(file, "font=%i\n", settings.font);
+    fprintf(file, "font=%s\n", settings.fontFile);
     fprintf(file, "color1=0x%06X\n", settings.color1_255);
     fprintf(file, "color2=0x%06X\n", settings.color2_255);
     fprintf(file, "color3=0x%06X\n", settings.color3_255);
@@ -1317,7 +1342,7 @@ void CFG_sync(void)
 void CFG_print(void)
 {
     printf("{\n");
-    printf("\t\"font\": %i,\n", settings.font);
+    printf("\t\"font\": \"%s\",\n", settings.fontFile);
     printf("\t\"color1\": \"0x%06X\",\n", settings.color1_255);
     printf("\t\"color2\": \"0x%06X\",\n", settings.color2_255);
     printf("\t\"color3\": \"0x%06X\",\n", settings.color3_255);
@@ -1358,10 +1383,11 @@ void CFG_print(void)
     printf("\t\"currentTimezone\": %i,\n", settings.currentTimezone);
 
     // meta, not a real setting
-    if (settings.font == 1)
-        printf("\t\"fontpath\": \"%s\"\n", RES_PATH "/font1.ttf");
+    const char *fp = CFG_getFontFile();
+    if (strcmp(fp, "font1.ttf") == 0 || strcmp(fp, "font2.ttf") == 0)
+        printf("\t\"fontpath\": \"%s/%s\"\n", RES_PATH, fp);
     else
-        printf("\t\"fontpath\": \"%s\"\n", RES_PATH "/font2.ttf");
+        printf("\t\"fontpath\": \"%s/%s\"\n", FONTS_PATH, fp);
 
     printf("}\n");
 }

--- a/workspace/all/common/config.h
+++ b/workspace/all/common/config.h
@@ -249,7 +249,7 @@ void CFG_get(const char *key, char * value);
 // void CFG_defaults(NextUISettings*);
 // The font filename to use as the UI font.
 // Built-in: "font1.ttf" (Next, default), "font2.ttf" (OG)
-// Custom fonts go in FONTS_PATH directory.
+// Custom fonts go in RES_PATH alongside built-in fonts.
 const char* CFG_getFontFile(void);
 void CFG_setFontFile(const char* filename);
 // The colors to use for the UI. These are 0xRRGGBB values.

--- a/workspace/all/common/config.h
+++ b/workspace/all/common/config.h
@@ -85,7 +85,7 @@ enum {
 typedef struct
 {
 	// Theme
-	int font;
+	char fontFile[256];
 	uint32_t color1_255; // not screen mapped
 	uint32_t color2_255; // not screen mapped
 	uint32_t color3_255; // not screen mapped
@@ -170,7 +170,7 @@ typedef struct
 #define TRANSITION_SNAPPY 1
 #define TRANSITION_COMFY  2
 
-#define CFG_DEFAULT_FONT_ID 1  // Next
+#define CFG_DEFAULT_FONT_FILE "font1.ttf"  // Next
 #define CFG_DEFAULT_COLOR1 0xffffffU
 #define CFG_DEFAULT_COLOR2 0x9b2257U
 #define CFG_DEFAULT_COLOR3 0x1e2329U
@@ -247,11 +247,11 @@ void CFG_init(FontLoad_callback_t fontCallback, ColorSet_callback_t ccb);
 void CFG_print(void);
 void CFG_get(const char *key, char * value);
 // void CFG_defaults(NextUISettings*);
-//  The font id to use as the UI font.
-//  0 - Default MinUI font
-//  1 - Default NextUI font (default)
-int CFG_getFontId(void);
-void CFG_setFontId(int fontid);
+// The font filename to use as the UI font.
+// Built-in: "font1.ttf" (Next, default), "font2.ttf" (OG)
+// Custom fonts go in FONTS_PATH directory.
+const char* CFG_getFontFile(void);
+void CFG_setFontFile(const char* filename);
 // The colors to use for the UI. These are 0xRRGGBB values.
 // 0 - Color1 (primary hint/asset colour)
 // 1 - Color2 (accent colour)

--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -17,6 +17,7 @@
 #define ROOT_SYSTEM_PATH SDCARD_PATH "/.system/"
 #define SYSTEM_PATH SDCARD_PATH "/.system/" PLATFORM
 #define RES_PATH SDCARD_PATH "/.system/res"
+#define FONTS_PATH RES_PATH "/fonts"
 #define USERDATA_PATH SDCARD_PATH "/.userdata/" PLATFORM
 #define SHARED_USERDATA_PATH SDCARD_PATH "/.userdata/shared"
 #define PAKS_PATH SYSTEM_PATH "/paks"

--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -17,7 +17,6 @@
 #define ROOT_SYSTEM_PATH SDCARD_PATH "/.system/"
 #define SYSTEM_PATH SDCARD_PATH "/.system/" PLATFORM
 #define RES_PATH SDCARD_PATH "/.system/res"
-#define FONTS_PATH RES_PATH "/fonts"
 #define USERDATA_PATH SDCARD_PATH "/.userdata/" PLATFORM
 #define SHARED_USERDATA_PATH SDCARD_PATH "/.userdata/shared"
 #define PAKS_PATH SYSTEM_PATH "/paks"

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -97,11 +97,16 @@ static std::vector<FontEntry> enumerateFonts() {
     fonts.push_back({"font1.ttf", "Next"});
     fonts.push_back({"font2.ttf", "OG"});
 
-    DIR *dir = opendir(FONTS_PATH);
+    DIR *dir = opendir(RES_PATH);
     if (dir) {
         struct dirent *ent;
         while ((ent = readdir(dir)) != NULL) {
             if (ent->d_name[0] == '.') continue;
+            // skip built-in/system fonts (font1/font2 already added above)
+            if (strcmp(ent->d_name, "font1.ttf") == 0 || strcmp(ent->d_name, "font2.ttf") == 0)
+                continue;
+            if (strncmp(ent->d_name, "BPreplay", 8) == 0)
+                continue;
             size_t len = strlen(ent->d_name);
             if (len < 5) continue;
             const char *ext = ent->d_name + len - 4;

--- a/workspace/all/settings/settings.cpp
+++ b/workspace/all/settings/settings.cpp
@@ -10,6 +10,7 @@ extern "C"
 }
 
 #include <csignal>
+#include <dirent.h>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -17,6 +18,7 @@ extern "C"
 #include <thread>
 #include <atomic>
 #include <mutex>
+#include <algorithm>
 #include "wifimenu.hpp"
 #include "btmenu.hpp"
 #include "keyboardprompt.hpp"
@@ -85,7 +87,38 @@ static const std::vector<std::string> color_strings = {
     "0x221100", "0x442200", "0x663300", "0x884400", "0xAA5500", "0xCC6600", "0xFF8833", "0xFF994D", "0xFFAA66", "0xFFBB80", "0xFFCC99", "0xFFDDB3",
     "0x000000", "0x141414", "0x282828", "0x3C3C3C", "0x505050", "0x646464", "0x8C8C8C", "0xA0A0A0", "0xB4B4B4", "0xC8C8C8", "0xDCDCDC", "0xFFFFFF"};
 
-static const std::vector<std::string> font_names = {"OG", "Next"};
+struct FontEntry {
+    std::string filename;
+    std::string label;
+};
+
+static std::vector<FontEntry> enumerateFonts() {
+    std::vector<FontEntry> fonts;
+    fonts.push_back({"font1.ttf", "Next"});
+    fonts.push_back({"font2.ttf", "OG"});
+
+    DIR *dir = opendir(FONTS_PATH);
+    if (dir) {
+        struct dirent *ent;
+        while ((ent = readdir(dir)) != NULL) {
+            if (ent->d_name[0] == '.') continue;
+            size_t len = strlen(ent->d_name);
+            if (len < 5) continue;
+            const char *ext = ent->d_name + len - 4;
+            if (strcasecmp(ext, ".ttf") != 0 && strcasecmp(ext, ".otf") != 0)
+                continue;
+
+            // build display name: strip extension, replace underscores
+            std::string label(ent->d_name, len - 4);
+            std::replace(label.begin(), label.end(), '_', ' ');
+
+            fonts.push_back({std::string(ent->d_name), label});
+        }
+        closedir(dir);
+    }
+
+    return fonts;
+}
 
 static const std::vector<std::any>    screen_timeout_secs = {0U, 5U, 10U, 15U, 30U, 45U, 60U, 90U, 120U, 240U, 360U, 600U};
 static const std::vector<std::string> screen_timeout_labels = {"Never", "5s", "10s", "15s", "30s", "45s", "60s", "90s", "2m", "4m", "6m", "10m"};
@@ -354,10 +387,17 @@ int main(int argc, char *argv[])
         }
 
         std::vector<AbstractMenuItem *> appearanceItems;
-        appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Font", "The font to render all UI text.", {0, 1}, font_names,
-            []() -> std::any{ return CFG_getFontId(); },
-            [](const std::any &value){ CFG_setFontId(std::any_cast<int>(value)); },
-            []() { CFG_setFontId(CFG_DEFAULT_FONT_ID);}});
+        auto fonts = enumerateFonts();
+        std::vector<std::any> font_values;
+        std::vector<std::string> font_labels;
+        for (const auto &f : fonts) {
+            font_values.push_back(f.filename);
+            font_labels.push_back(f.label);
+        }
+        appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Font", "The font to render all UI text.", font_values, font_labels,
+            []() -> std::any { return std::string(CFG_getFontFile()); },
+            [](const std::any &value) { CFG_setFontFile(std::any_cast<std::string>(value).c_str()); },
+            []() { CFG_setFontFile(CFG_DEFAULT_FONT_FILE); }});
         for (auto *item : colorMenuItems)
             appearanceItems.push_back(item);
         appearanceItems.push_back(new MenuItem{ListItemType::Generic, "Show battery percentage", "Show battery level as percent in the status pill", {false, true}, on_off,


### PR DESCRIPTION
## Summary
- Users can drop .ttf/.otf files into `.system/res/` and they appear in the Settings font picker
- Built-in fonts ("Next" and "OG") remain available as always
- Built-in fonts write integer values to `minuisettings.txt` (`font=0` for OG, `font=1` for Next) for backward compatibility with existing paks
- Custom fonts write the filename (e.g. `font=MyFont.ttf`)
- `nextval font` always returns an integer (default `1` for custom fonts); paks should use `nextval fontpath` for the full path
- Backward compatible with existing `font=0`/`font=1` integer values on read
- Falls back to default font if a selected custom font file is removed

**Note:** All binaries linking `config.c` (nextui, minarch, nextval, settings, clock, etc.) must be rebuilt — the settings struct changed from integer to string for the font field internally.

### Pak compatibility
Audited all 87 pak store repos + 3 related projects. Only 2 read the `font=` setting (Apostrophe library and NextUI Updater), both parsing it as an integer. Built-in font selections remain fully compatible. Custom font selections gracefully degrade — Apostrophe-based paks fall back to the default font until updated.

## Test plan
- [x] Verify built-in fonts ("Next", "OG") still work and persist across reboots
- [x] Drop a .ttf into `.system/res/`, open Settings — font appears in picker
- [x] Select custom font, reboot — selection persists
- [x] Select custom font, launch and quit a game — selection persists
- [x] Remove the custom font file, reboot — falls back to default "Next"
- [x] Existing installs with `font=0` or `font=1` in settings file still work
- [x] Aesthetics pak works with custom font selected
- [x] Clock pak does not overwrite custom font selection