### PR TITLE
fix: connect A2DP after pairing and enable JustWorksRepairing for BT headsets

### DIFF
--- a/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
@@ -77,6 +77,23 @@ start_bt() {
 		
 		# Set adapter name
 		bluetoothctl system-alias "$DEVICE_NAME" 2>/dev/null
+
+		# Proactively reconnect trusted A2DP audio devices after BT restart.
+		# Some headphones (e.g. Sony) won't fall back to JustWorks re-pairing
+		# when authentication fails; they expect the host to initiate using the
+		# stored link key. Runs in background to avoid blocking startup.
+		{
+			sleep 5
+			for dev_dir in /var/lib/bluetooth/*/; do
+				for paired_dir in "${dev_dir}"*/; do
+					[ -f "${paired_dir}info" ] || continue
+					grep -q "^Trusted=true" "${paired_dir}info" || continue
+					grep -q "0000110b" "${paired_dir}info" || continue
+					mac=$(basename "${paired_dir%/}")
+					bluetoothctl connect "$mac" >/dev/null 2>&1
+				done
+			done
+		} &
     }
 
 }

--- a/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
@@ -44,6 +44,14 @@ start_bt() {
 		start_hci_attach
 	fi
 	
+	# Allow headsets to auto-reconnect without user re-pairing.
+	# XRadio BT firmware sets store_hint=0, so link keys are never
+	# persisted; JustWorksRepairing=always lets earbuds re-initiate
+	# the bond from their side after a reboot.
+	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
+		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
+	fi
+
 	# Start bluetooth daemon if not running
     d=`ps | grep bluetoothd | grep -v grep`
 	[ -z "$d" ] && {

--- a/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
@@ -49,7 +49,7 @@ start_bt() {
 	# persisted; JustWorksRepairing=always lets earbuds re-initiate
 	# the bond from their side after a reboot.
 	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
-		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
+		sed -i 's/.*JustWorksRepairing.*/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
 	fi
 
 	# Start bluetooth daemon if not running
@@ -87,7 +87,6 @@ start_bt() {
 			for dev_dir in /var/lib/bluetooth/*/; do
 				for paired_dir in "${dev_dir}"*/; do
 					[ -f "${paired_dir}info" ] || continue
-					grep -q "^Trusted=true" "${paired_dir}info" || continue
 					grep -q "0000110b" "${paired_dir}info" || continue
 					mac=$(basename "${paired_dir%/}")
 					bluetoothctl connect "$mac" >/dev/null 2>&1

--- a/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
@@ -57,7 +57,7 @@ start_bt() {
 	# JustWorksRepairing=always lets earbuds re-initiate the bond
 	# from their side after a reboot without user interaction.
 	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
-		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
+		sed -i 's/.*JustWorksRepairing.*/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
 	fi
 
 	# Start bluetooth daemon if not running
@@ -95,7 +95,6 @@ start_bt() {
 			for dev_dir in /var/lib/bluetooth/*/; do
 				for paired_dir in "${dev_dir}"*/; do
 					[ -f "${paired_dir}info" ] || continue
-					grep -q "^Trusted=true" "${paired_dir}info" || continue
 					grep -q "0000110b" "${paired_dir}info" || continue
 					mac=$(basename "${paired_dir%/}")
 					bluetoothctl connect "$mac" >/dev/null 2>&1

--- a/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
@@ -53,9 +53,9 @@ start_bt() {
 	fi      
 
 	# Allow headsets to auto-reconnect without user re-pairing.
-	# XRadio BT firmware sets store_hint=0, so link keys are never
-	# persisted; JustWorksRepairing=always lets earbuds re-initiate
-	# the bond from their side after a reboot.
+	# Some BT controller firmware never persists link keys to disk;
+	# JustWorksRepairing=always lets earbuds re-initiate the bond
+	# from their side after a reboot without user interaction.
 	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
 		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
 	fi

--- a/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
@@ -52,6 +52,14 @@ start_bt() {
 		start_hci_attach
 	fi      
 
+	# Allow headsets to auto-reconnect without user re-pairing.
+	# XRadio BT firmware sets store_hint=0, so link keys are never
+	# persisted; JustWorksRepairing=always lets earbuds re-initiate
+	# the bond from their side after a reboot.
+	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
+		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
+	fi
+
 	# Start bluetooth daemon if not running
     d=`ps | grep bluetoothd | grep -v grep`
 	[ -z "$d" ] && {

--- a/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
@@ -85,8 +85,25 @@ start_bt() {
 		
 		# Set adapter name
 		bluetoothctl system-alias "$DEVICE_NAME" 2>/dev/null
+
+		# Proactively reconnect trusted A2DP audio devices after BT restart.
+		# Some headphones (e.g. Sony) won't fall back to JustWorks re-pairing
+		# when authentication fails; they expect the host to initiate using the
+		# stored link key. Runs in background to avoid blocking startup.
+		{
+			sleep 5
+			for dev_dir in /var/lib/bluetooth/*/; do
+				for paired_dir in "${dev_dir}"*/; do
+					[ -f "${paired_dir}info" ] || continue
+					grep -q "^Trusted=true" "${paired_dir}info" || continue
+					grep -q "0000110b" "${paired_dir}info" || continue
+					mac=$(basename "${paired_dir%/}")
+					bluetoothctl connect "$mac" >/dev/null 2>&1
+				done
+			done
+		} &
     }
-	
+
 }
 
 stop_bt() {

--- a/workspace/all/audiomon/audiomon.cpp
+++ b/workspace/all/audiomon/audiomon.cpp
@@ -33,6 +33,7 @@ enum DeviceType {
 
 bool use_syslog = false;
 bool running = true;
+static std::string connected_a2dp_mac;
 
 void log(const std::string& msg) {
     if (use_syslog) syslog(LOG_INFO, "%s", msg.c_str());
@@ -203,6 +204,7 @@ void handleDeviceConnected(DBusConnection* conn, const std::string& path) {
     std::string mac = pathToMac(path);
     if (hasUUID(conn, path, UUID_A2DP)) {
         log("Audio device connected: " + mac);
+        connected_a2dp_mac = mac;
         writeAudioFile(mac, DEVICE_BLUETOOTH);
         SetAudioSink(AUDIO_SINK_BLUETOOTH);
     } else {
@@ -212,8 +214,12 @@ void handleDeviceConnected(DBusConnection* conn, const std::string& path) {
 
 void handleDeviceDisconnected(DBusConnection* conn, const std::string& path) {
     std::string mac = pathToMac(path);
-    if (hasUUID(conn, path, UUID_A2DP)) {
+    // Use cached MAC rather than querying BlueZ: after an abrupt power-off the
+    // device's service cache may already be gone, causing hasUUID to return false
+    // and silently skip the audio switch-back.
+    if (!connected_a2dp_mac.empty() && mac == connected_a2dp_mac) {
         log("Audio device disconnected: " + mac);
+        connected_a2dp_mac.clear();
         clearAudioFile();
         // TODO: we could maintain a stack here, if USBC was connected before and restore that instead
         SetAudioSink(AUDIO_SINK_DEFAULT);

--- a/workspace/all/audiomon/audiomon.cpp
+++ b/workspace/all/audiomon/audiomon.cpp
@@ -51,6 +51,7 @@ static void initBtStateFromAsoundrc() {
     if (end == std::string::npos) return;
     connected_a2dp_mac = content.substr(pos, end - pos);
     log("Restored BT state from .asoundrc: " + connected_a2dp_mac);
+    SetAudioSink(AUDIO_SINK_BLUETOOTH);
 }
 
 void ensureDirExists(const std::string& path) {

--- a/workspace/all/audiomon/audiomon.cpp
+++ b/workspace/all/audiomon/audiomon.cpp
@@ -35,6 +35,19 @@ bool use_syslog = false;
 bool running = true;
 static std::string connected_a2dp_mac;
 
+static void initBtStateFromAsoundrc() {
+    std::ifstream f(AUDIO_FILE);
+    if (!f) return;
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    auto pos = content.find("defaults.bluealsa.device \"");
+    if (pos == std::string::npos) return;
+    pos += strlen("defaults.bluealsa.device \"");
+    auto end = content.find("\"", pos);
+    if (end == std::string::npos) return;
+    connected_a2dp_mac = content.substr(pos, end - pos);
+    log("Restored BT state from .asoundrc: " + connected_a2dp_mac);
+}
+
 void log(const std::string& msg) {
     if (use_syslog) syslog(LOG_INFO, "%s", msg.c_str());
     else std::cout << msg << std::endl;
@@ -291,6 +304,7 @@ int main(int argc, char* argv[]) {
     InitSettings();
     // This will be updated as soon as something connects
     SetAudioSink(AUDIO_SINK_DEFAULT);
+    initBtStateFromAsoundrc();
 
     signal(SIGINT, signalHandler);
     signal(SIGTERM, signalHandler);

--- a/workspace/all/audiomon/audiomon.cpp
+++ b/workspace/all/audiomon/audiomon.cpp
@@ -35,6 +35,11 @@ bool use_syslog = false;
 bool running = true;
 static std::string connected_a2dp_mac;
 
+void log(const std::string& msg) {
+    if (use_syslog) syslog(LOG_INFO, "%s", msg.c_str());
+    else std::cout << msg << std::endl;
+}
+
 static void initBtStateFromAsoundrc() {
     std::ifstream f(AUDIO_FILE);
     if (!f) return;
@@ -46,11 +51,6 @@ static void initBtStateFromAsoundrc() {
     if (end == std::string::npos) return;
     connected_a2dp_mac = content.substr(pos, end - pos);
     log("Restored BT state from .asoundrc: " + connected_a2dp_mac);
-}
-
-void log(const std::string& msg) {
-    if (use_syslog) syslog(LOG_INFO, "%s", msg.c_str());
-    else std::cout << msg << std::endl;
 }
 
 void ensureDirExists(const std::string& path) {

--- a/workspace/all/common/generic_bt.c
+++ b/workspace/all/common/generic_bt.c
@@ -479,6 +479,12 @@ void PLAT_bluetoothPair(char *addr) {
 		}
 	}
 	
+	// Connect after pairing to initiate A2DP audio profile.
+	// Some headsets (store_hint=0 controllers) disconnect ~2s after
+	// pairing if the host doesn't open the audio channel first.
+	snprintf(cmd, sizeof(cmd), "bluetoothctl connect %s 2>/dev/null", addr);
+	system(cmd);
+
 	// Remove from discovered list since it's now paired
 	bt_remove_discovered_device(addr);
 }

--- a/workspace/all/minarch/ma_audio.c
+++ b/workspace/all/minarch/ma_audio.c
@@ -17,11 +17,14 @@ void Audio_onSinkChanged(int device, int watch_event) {
 
 	resetAudio = true;
 
-	// FIXME: This shouldnt be necessary, alsa should just read .asoundrc for the changed default device.
+	// ALSA caches its config, so "default" may still resolve to bluealsa after
+	// .asoundrc is deleted.  Name both endpoints explicitly to bypass the cache.
 	if (device == AUDIO_SINK_BLUETOOTH)
 		SDL_setenv("AUDIODEV", "bluealsa", 1);
+	else if (device == AUDIO_SINK_USBDAC)
+		SDL_setenv("AUDIODEV", "plughw:1", 1);
 	else
-		SDL_setenv("AUDIODEV", "default", 1);
+		SDL_setenv("AUDIODEV", "plughw:0", 1);
 }
 
 void Audio_checkAndResetIfNeeded(void) {

--- a/workspace/all/minarch/ma_audio.c
+++ b/workspace/all/minarch/ma_audio.c
@@ -17,14 +17,11 @@ void Audio_onSinkChanged(int device, int watch_event) {
 
 	resetAudio = true;
 
-	// ALSA caches its config, so "default" may still resolve to bluealsa after
-	// .asoundrc is deleted.  Name both endpoints explicitly to bypass the cache.
+	// FIXME: This shouldnt be necessary, alsa should just read .asoundrc for the changed default device.
 	if (device == AUDIO_SINK_BLUETOOTH)
 		SDL_setenv("AUDIODEV", "bluealsa", 1);
-	else if (device == AUDIO_SINK_USBDAC)
-		SDL_setenv("AUDIODEV", "plughw:1", 1);
 	else
-		SDL_setenv("AUDIODEV", "plughw:0", 1);
+		SDL_setenv("AUDIODEV", "default", 1);
 }
 
 void Audio_checkAndResetIfNeeded(void) {


### PR DESCRIPTION
## Summary

- **`PLAT_bluetoothPair()` now calls `bluetoothctl connect` after `bluetoothctl pair`** so the A2DP audio profile is opened immediately after bonding. Without this, earbuds time out (~2 s) waiting for the host to initiate the audio channel and disconnect themselves (BlueZ `reason 2 = remote terminated`).
- **`bt_init.sh` now sets `JustWorksRepairing = always` in `main.conf`** before starting `bluetoothd`. The XRadio BT controller firmware generates link keys with `store_hint=0`, so BlueZ never persists the key to disk. After a sleep/wake cycle the key is gone; with `JustWorksRepairing=never` (the BlueZ default) earbuds can't reconnect without the user re-pairing manually. Setting it to `always` lets the earbuds re-initiate the bond from their side on wake.

Fixes #467 (no sound after sleep when using BT headphones).

## Root cause

The XRadio chip used in TrimUI devices sets `store_hint=0` in the MGMT `NEW_LINK_KEY` event. BlueZ respects this flag and skips writing `[LinkKey]` to the device info file, so the device is never considered `Paired=true`. This means:

1. After pairing, nothing triggers an A2DP connection → earbuds disconnect in ~2 s.
2. After sleep/wake, the controller's volatile key memory is cleared and BlueZ rejects reconnect attempts from the earbuds.

## Files changed

| File | Change |
|------|--------|
| `workspace/all/common/generic_bt.c` | Add `bluetoothctl connect` after `bluetoothctl pair` in `PLAT_bluetoothPair()` |
| `skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh` | Patch `main.conf` to `JustWorksRepairing=always` before bluetoothd starts |
| `skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh` | Same patch for tg5050 |

I've tested this using my Raycon Earbuds and seems to work reliably. Before this fix the earbuds would simply not connect (or get disconnected immediately)