### PR TITLE
fix: cpu stuck in performance mode on fresh install

### DIFF
--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -139,7 +139,7 @@ int main(int argc , char* argv[]) {
 	if(argc < 2)
 		return EXIT_FAILURE;
 
-	setOverclock(1); // start up in performance mode, faster init
+	setOverclock(CPU_SPEED_AUTO); // start in auto as default
 	PWR_pinToCores(CPU_CORE_PERFORMANCE); // thread affinity
 
 	char core_path[MAX_PATH];
@@ -182,7 +182,7 @@ int main(int argc , char* argv[]) {
 	Config_load(); // before init?
 	Config_init();
 	Config_readOptions(); // cores with boot logo option (eg. gb) need to load options early
-	setOverclock(overclock); // why twice?
+	setOverclock(overclock); // we started in auto, now reset to value loaded from config
 	
 	Core_init();
 

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -139,7 +139,7 @@ int main(int argc , char* argv[]) {
 	if(argc < 2)
 		return EXIT_FAILURE;
 
-	setOverclock(CPU_SPEED_AUTO); // start in auto as default
+	PWR_setCPUSpeed(CPU_SPEED_PERFORMANCE); // start in performance mode for fast loading
 	PWR_pinToCores(CPU_CORE_PERFORMANCE); // thread affinity
 
 	char core_path[MAX_PATH];
@@ -182,7 +182,6 @@ int main(int argc , char* argv[]) {
 	Config_load(); // before init?
 	Config_init();
 	Config_readOptions(); // cores with boot logo option (eg. gb) need to load options early
-	setOverclock(overclock); // we started in auto, now reset to value loaded from config
 	
 	Core_init();
 
@@ -250,6 +249,11 @@ int main(int argc , char* argv[]) {
 	Config_free();
 
 	LOG_info("total startup time %ims\n\n",SDL_GetTicks());
+	
+	// we started in performance mode, now reset to the desired mode
+	// if the config didn't specify the desired cpu speed, the default is 0 = auto
+	setOverclock(overclock);
+
 	while (!quit) {
 		GFX_startFrame();
 


### PR DESCRIPTION
This fixes a bug where on fresh install i.e. when the CPU speed for minarch has not otherwise been changed, the CPU Speed stays stuck in Performance mode even though the UI shows Auto.

This is because minarch calls setOverclock(1) to upgrade to performance mode, but this overwrites the "overclock" variable. If a subsequent "Config_readoptions()" call does not reset it back to something else, the cpu will silently stay in performance mode while the UI shows the default option of Auto.

The fix is to set Auto cpu mode explicitly when minarch starts. At present this selects schedutil from min to one less than the max frequency. On TG5040 this is 10% slower clock, so startup time of every game will be 10% slower. But this is of the order of 100-200 ms, while the power and thermal savings are massive.

Closes #732