### PR TITLE
Fix/recents resume hint on quick menu nav

### DIFF
--- a/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5040/etc/bluetooth/bt_init.sh
@@ -44,6 +44,14 @@ start_bt() {
 		start_hci_attach
 	fi
 	
+	# Allow headsets to auto-reconnect without user re-pairing.
+	# XRadio BT firmware sets store_hint=0, so link keys are never
+	# persisted; JustWorksRepairing=always lets earbuds re-initiate
+	# the bond from their side after a reboot.
+	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
+		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
+	fi
+
 	# Start bluetooth daemon if not running
     d=`ps | grep bluetoothd | grep -v grep`
 	[ -z "$d" ] && {

--- a/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
@@ -53,9 +53,9 @@ start_bt() {
 	fi      
 
 	# Allow headsets to auto-reconnect without user re-pairing.
-	# XRadio BT firmware sets store_hint=0, so link keys are never
-	# persisted; JustWorksRepairing=always lets earbuds re-initiate
-	# the bond from their side after a reboot.
+	# Some BT controller firmware never persists link keys to disk;
+	# JustWorksRepairing=always lets earbuds re-initiate the bond
+	# from their side after a reboot without user interaction.
 	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
 		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
 	fi

--- a/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
+++ b/skeleton/SYSTEM/tg5050/etc/bluetooth/bt_init.sh
@@ -52,6 +52,14 @@ start_bt() {
 		start_hci_attach
 	fi      
 
+	# Allow headsets to auto-reconnect without user re-pairing.
+	# XRadio BT firmware sets store_hint=0, so link keys are never
+	# persisted; JustWorksRepairing=always lets earbuds re-initiate
+	# the bond from their side after a reboot.
+	if ! grep -q 'JustWorksRepairing = always' /etc/bluetooth/main.conf 2>/dev/null; then
+		sed -i 's/#JustWorksRepairing = never/JustWorksRepairing = always/' /etc/bluetooth/main.conf 2>/dev/null
+	fi
+
 	# Start bluetooth daemon if not running
     d=`ps | grep bluetoothd | grep -v grep`
 	[ -z "$d" ] && {

--- a/workspace/all/audiomon/audiomon.cpp
+++ b/workspace/all/audiomon/audiomon.cpp
@@ -33,6 +33,7 @@ enum DeviceType {
 
 bool use_syslog = false;
 bool running = true;
+static std::string connected_a2dp_mac;
 
 void log(const std::string& msg) {
     if (use_syslog) syslog(LOG_INFO, "%s", msg.c_str());
@@ -203,6 +204,7 @@ void handleDeviceConnected(DBusConnection* conn, const std::string& path) {
     std::string mac = pathToMac(path);
     if (hasUUID(conn, path, UUID_A2DP)) {
         log("Audio device connected: " + mac);
+        connected_a2dp_mac = mac;
         writeAudioFile(mac, DEVICE_BLUETOOTH);
         SetAudioSink(AUDIO_SINK_BLUETOOTH);
     } else {
@@ -212,8 +214,12 @@ void handleDeviceConnected(DBusConnection* conn, const std::string& path) {
 
 void handleDeviceDisconnected(DBusConnection* conn, const std::string& path) {
     std::string mac = pathToMac(path);
-    if (hasUUID(conn, path, UUID_A2DP)) {
+    // Use cached MAC rather than querying BlueZ: after an abrupt power-off the
+    // device's service cache may already be gone, causing hasUUID to return false
+    // and silently skip the audio switch-back.
+    if (!connected_a2dp_mac.empty() && mac == connected_a2dp_mac) {
         log("Audio device disconnected: " + mac);
+        connected_a2dp_mac.clear();
         clearAudioFile();
         // TODO: we could maintain a stack here, if USBC was connected before and restore that instead
         SetAudioSink(AUDIO_SINK_DEFAULT);

--- a/workspace/all/common/generic_bt.c
+++ b/workspace/all/common/generic_bt.c
@@ -479,6 +479,12 @@ void PLAT_bluetoothPair(char *addr) {
 		}
 	}
 	
+	// Connect after pairing to initiate A2DP audio profile.
+	// Some headsets (store_hint=0 controllers) disconnect ~2s after
+	// pairing if the host doesn't open the audio channel first.
+	snprintf(cmd, sizeof(cmd), "bluetoothctl connect %s 2>/dev/null", addr);
+	system(cmd);
+
 	// Remove from discovered list since it's now paired
 	bt_remove_discovered_device(addr);
 }

--- a/workspace/all/minarch/ma_audio.c
+++ b/workspace/all/minarch/ma_audio.c
@@ -17,11 +17,14 @@ void Audio_onSinkChanged(int device, int watch_event) {
 
 	resetAudio = true;
 
-	// FIXME: This shouldnt be necessary, alsa should just read .asoundrc for the changed default device.
+	// ALSA caches its config, so "default" may still resolve to bluealsa after
+	// .asoundrc is deleted.  Name both endpoints explicitly to bypass the cache.
 	if (device == AUDIO_SINK_BLUETOOTH)
 		SDL_setenv("AUDIODEV", "bluealsa", 1);
+	else if (device == AUDIO_SINK_USBDAC)
+		SDL_setenv("AUDIODEV", "plughw:1", 1);
 	else
-		SDL_setenv("AUDIODEV", "default", 1);
+		SDL_setenv("AUDIODEV", "plughw:0", 1);
 }
 
 void Audio_checkAndResetIfNeeded(void) {

--- a/workspace/all/minarch/ma_audio.c
+++ b/workspace/all/minarch/ma_audio.c
@@ -17,14 +17,11 @@ void Audio_onSinkChanged(int device, int watch_event) {
 
 	resetAudio = true;
 
-	// ALSA caches its config, so "default" may still resolve to bluealsa after
-	// .asoundrc is deleted.  Name both endpoints explicitly to bypass the cache.
+	// FIXME: This shouldnt be necessary, alsa should just read .asoundrc for the changed default device.
 	if (device == AUDIO_SINK_BLUETOOTH)
 		SDL_setenv("AUDIODEV", "bluealsa", 1);
-	else if (device == AUDIO_SINK_USBDAC)
-		SDL_setenv("AUDIODEV", "plughw:1", 1);
 	else
-		SDL_setenv("AUDIODEV", "plughw:0", 1);
+		SDL_setenv("AUDIODEV", "default", 1);
 }
 
 void Audio_checkAndResetIfNeeded(void) {

--- a/workspace/all/minarch/ma_config.c
+++ b/workspace/all/minarch/ma_config.c
@@ -185,9 +185,8 @@ void Config_syncFrontend(char* key, int value) {
 			case FE_OPT_REWIND_COMPRESSION: rewind_cfg_compress = parsed; break;
 			case FE_OPT_REWIND_COMPRESSION_ACCEL: rewind_cfg_lz4_acceleration = parsed; break;
 		}
-		// Only call Rewind_init if core is initialized; early config reads happen before
-		// the core is ready and will be followed by an explicit Rewind_init later
-		if (core.initialized) {
+		// Defer Rewind_init until after the explicit init in main(), otherwise FBN crashes
+		if (rewind_init_ready) {
 			Rewind_init(core.serialize_size ? core.serialize_size() : 0);
 		}
 		if (i==FE_OPT_REWIND_ENABLE) {

--- a/workspace/all/minarch/ma_internal.h
+++ b/workspace/all/minarch/ma_internal.h
@@ -126,6 +126,7 @@ extern int rewind_cfg_granularity;
 extern int rewind_cfg_audio;
 extern int rewind_cfg_compress;
 extern int rewind_cfg_lz4_acceleration;
+extern int rewind_init_ready;
 
 #include "ma_rewind.h"
 

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -57,6 +57,7 @@ int rewind_cfg_granularity = MINARCH_DEFAULT_REWIND_GRANULARITY;
 int rewind_cfg_audio = MINARCH_DEFAULT_REWIND_AUDIO;
 int rewind_cfg_compress = 1;
 int rewind_cfg_lz4_acceleration = MINARCH_DEFAULT_REWIND_LZ4_ACCELERATION;
+int rewind_init_ready = 0; // gate Rewind_init from syncFrontend until startup is past Core_load
 int overclock = 0; // auto
 int has_custom_controllers = 0;
 int gamepad_type = 0; // index in gamepad_labels/gamepad_values
@@ -242,8 +243,9 @@ int main(int argc , char* argv[]) {
 	initShaders();
 	Config_readOptions();
 	applyShaderSettings();
-	Rewind_init(core.serialize_size ? core.serialize_size() : 0);
-	if (core.serialize_size) Rewind_on_state_change();
+	int rewind_initialized = Rewind_init(core.serialize_size ? core.serialize_size() : 0);
+	rewind_init_ready = 1;  // Mark setup as attempted, even if rewind init failed, so option changes can retry it later.
+	if (rewind_initialized && core.serialize_size) Rewind_on_state_change();
 	// release config when all is loaded
 	Config_free();
 

--- a/workspace/all/minarch/minarch.c
+++ b/workspace/all/minarch/minarch.c
@@ -139,7 +139,7 @@ int main(int argc , char* argv[]) {
 	if(argc < 2)
 		return EXIT_FAILURE;
 
-	setOverclock(1); // start up in performance mode, faster init
+	PWR_setCPUSpeed(CPU_SPEED_PERFORMANCE); // start in performance mode for fast loading
 	PWR_pinToCores(CPU_CORE_PERFORMANCE); // thread affinity
 
 	char core_path[MAX_PATH];
@@ -182,7 +182,6 @@ int main(int argc , char* argv[]) {
 	Config_load(); // before init?
 	Config_init();
 	Config_readOptions(); // cores with boot logo option (eg. gb) need to load options early
-	setOverclock(overclock); // why twice?
 	
 	Core_init();
 
@@ -250,6 +249,11 @@ int main(int argc , char* argv[]) {
 	Config_free();
 
 	LOG_info("total startup time %ims\n\n",SDL_GetTicks());
+	
+	// we started in performance mode, now reset to the desired mode
+	// if the config didn't specify the desired cpu speed, the default is 0 = auto
+	setOverclock(overclock);
+
 	while (!quit) {
 		GFX_startFrame();
 

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -2341,6 +2341,7 @@ int main (int argc, char *argv[]) {
 					restore_end = 0;
 				}
 				Entry_open(selected);
+				if (top->entries->count > 0) readyResume(top->entries->items[top->selected]);
 				dirty = 1;
 			}
 			else if (PAD_justPressed(BTN_RIGHT)) {


### PR DESCRIPTION
  fix: call readyResume when navigating to a directory via Quick Menu

  When selecting an entry (e.g. Recents) from the Quick Menu, the
  SCREEN_QUICKMENU input block handles the A press and calls Entry_open,
  but never calls readyResume for the newly-selected first entry of the
  opened directory. As a result, can_resume retains its stale value and
  the footer shows "Power: Sleep" instead of "X: Resume" until the user
  scrolls to trigger a readyResume call.

  Normal navigation (pressing A on "Recently Played" in the game list)
  already calls readyResume immediately after Entry_open. Mirror that
  same call in the Quick Menu A-press handler.

  Fixes #737