### PR TITLE
fix: call readyResume when navigating to a directory via Quick Menu

### DIFF
--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -2341,6 +2341,7 @@ int main (int argc, char *argv[]) {
 					restore_end = 0;
 				}
 				Entry_open(selected);
+				if (top->entries->count > 0) readyResume(top->entries->items[top->selected]);
 				dirty = 1;
 			}
 			else if (PAD_justPressed(BTN_RIGHT)) {


### PR DESCRIPTION
When selecting an entry (e.g. Recents) from the Quick Menu, the SCREEN_QUICKMENU input block handles the A press and calls Entry_open, but never calls readyResume for the newly-selected first entry of the opened directory. As a result, can_resume retains its stale value and the footer shows "Power: Sleep" instead of "X: Resume" until the user scrolls to trigger a readyResume call.

Normal navigation (pressing A on "Recently Played" in the game list) already calls readyResume immediately after Entry_open. Mirror that same call in the Quick Menu A-press handler.

Fixes #737