### PR TITLE
fix: wrong label on game switcher entries w/o save state

### DIFF
--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -2820,10 +2820,10 @@ int main (int argc, char *argv[]) {
 						SDL_FreeSurface(text);
 					}
 
-					if(can_resume) GFX_blitButtonGroup((char*[]){ "B","BACK",  NULL }, 0, screen, 0);
-					else GFX_blitButtonGroup((char*[]){ BTN_SLEEP==BTN_POWER?"POWER":"MENU","SLEEP",  NULL }, 0, screen, 0);
+					GFX_blitButtonGroup((char*[]){ "B","BACK",  NULL }, 0, screen, 0);
 
-					GFX_blitButtonGroup((char*[]){ "Y", "REMOVE", "A","RESUME", NULL }, 1, screen, 1);
+					if(can_resume) GFX_blitButtonGroup((char*[]){ "Y", "REMOVE", "A","RESUME", NULL }, 1, screen, 1);
+					else GFX_blitButtonGroup((char*[]){ "A","OPEN", NULL }, 1, screen, 1);
 
 					if(has_preview) {
 						// lotta memory churn here


### PR DESCRIPTION
#134 