### PR TITLE
Fix/sleep wakeup followup

### DIFF
--- a/workspace/all/audiomon/audiomon.cpp
+++ b/workspace/all/audiomon/audiomon.cpp
@@ -276,15 +276,8 @@ void handleDeviceDisconnected(DBusConnection* conn, const std::string& path) {
         log("Audio device disconnected: " + mac);
         connected_a2dp_mac.clear();
         clearAudioFile();
-        // In case BT just disconnected, chances are that bluealsa is throwing weird PCM errors
-        // on recovering the connection. It seems the only way to avoid this is to straight up kill and restart bluealsa...‚
-        system("killall bluealsa");
-        for (int i = 0; i < 20; i++) {
-            if (system("pidof bluealsa > /dev/null 2>&1") != 0) break;
-            usleep(100000); // 100ms
-        }
-        system("bluealsa -p a2dp-source --keep-alive=10 &");
-        
+        // Do not restart bluealsa here: tearing it down while a game is actively
+        // streaming through ALSA can block the frontend audio path.
         // TODO: we could maintain a stack here, if USBC was connected before and restore that instead
         SetAudioSink(AUDIO_SINK_DEFAULT);
     }

--- a/workspace/all/common/generic_bt.c
+++ b/workspace/all/common/generic_bt.c
@@ -697,7 +697,9 @@ static void *watcher_thread_func(void *arg) {
                 if (event->mask & (IN_MODIFY | IN_CLOSE_WRITE | IN_DELETE_SELF)) {
                     if (event->mask & IN_DELETE_SELF) {
                         remove_file_watch();
-						if (callback_fn) callback_fn(AUDIO_SINK_DEFAULT, FILEWATCH_DELETE);
+						// Deleting .asoundrc while a core is running can force an
+						// unsafe live audio sink transition. Ignore delete events;
+						// rely on subsequent create/modify when a new sink appears.
                     }
 					// No need to react to this, it usually comes paired with FILEWATCH_MODIFY
 					//else if (event->mask & IN_CLOSE_WRITE) {

--- a/workspace/tg5040/platform/platform.c
+++ b/workspace/tg5040/platform/platform.c
@@ -333,11 +333,11 @@ void PLAT_setRumble(int strength) {
 
 int PLAT_pickSampleRate(int requested, int max) {
 	// bluetooth: allow limiting the maximum to improve compatibility.
-	// Some cores request non-standard rates (>48k). For those, prefer 44.1k
-	// over 48k to avoid unstable A2DP renegotiation on certain headsets.
+	// Some cores request 48k or non-standard rates (>48k). Prefer 44.1k over
+	// 48k on Bluetooth to avoid unstable A2DP behavior on certain headsets.
 	if(PLAT_bluetoothConnected()) {
 		int limit = MIN(max, CFG_getBluetoothSamplingrateLimit());
-		if (requested > 48000)
+		if (requested >= 48000)
 			return MIN(44100, limit);
 		return MIN(requested, limit);
 	}

--- a/workspace/tg5050/platform/platform.c
+++ b/workspace/tg5050/platform/platform.c
@@ -371,11 +371,11 @@ void PLAT_setRumble(int strength) {
 
 int PLAT_pickSampleRate(int requested, int max) {
 	// bluetooth: allow limiting the maximum to improve compatibility.
-	// Some cores request non-standard rates (>48k). For those, prefer 44.1k
-	// over 48k to avoid unstable A2DP renegotiation on certain headsets.
+	// Some cores request 48k or non-standard rates (>48k). Prefer 44.1k over
+	// 48k on Bluetooth to avoid unstable A2DP behavior on certain headsets.
 	if(PLAT_bluetoothConnected()) {
 		int limit = MIN(max, CFG_getBluetoothSamplingrateLimit());
-		if (requested > 48000)
+		if (requested >= 48000)
 			return MIN(44100, limit);
 		return MIN(requested, limit);
 	}


### PR DESCRIPTION
Prevents runtime audio teardown when earbuds disconnect by removing an aggressive bluealsa restart and ignoring .asoundrc delete watch events that could trigger unsafe live sink switching. This fixes in-game freezes and allows clean fallback to speakers.

 Extends the Bluetooth sample-rate fallback from >48k to >=48k, so exact 48000 Hz cores follow the same stable path as other problematic high-rate cores. This improves compatibility across cores/headsets and avoids silent/unstable BT audio behavior.